### PR TITLE
Add CP2K Made Simple examples

### DIFF
--- a/cp2k-made-simple/README.md
+++ b/cp2k-made-simple/README.md
@@ -1,0 +1,33 @@
+# CP2K Made Simple Examples
+
+This directory collects CP2K input material associated with the paper
+["The CP2K Program Package Made Simple"](https://doi.org/10.1021/acs.jpcb.5c05851).
+
+The directory has two parts:
+
+- `runnable/` contains small, complete input files derived from selected paper snippets. They
+  can be run directly with a CP2K binary and a standard CP2K data directory.
+- `paper-snippets/` contains 91 CP2K input fragments extracted from the paper. Many of these
+  fragments intentionally show only the method-specific section and contain placeholders such as
+  `...`, so they are not standalone calculations.
+
+The full list of extracted snippets is in `manifest.tsv`. The snippet numbering follows the order
+of code blocks in the paper HTML source used for extraction.
+The derived complete examples are listed in `runnable/manifest.tsv`.
+
+## Running the Complete Examples
+
+From this directory, run for example:
+
+```bash
+cp2k.psmp -i runnable/dft/h2o-gpw-pbe.inp -o h2o-gpw-pbe.out
+cp2k.psmp -i runnable/gapw/h2o-gapw-all-electron.inp -o h2o-gapw-all-electron.out
+```
+
+If CP2K was built without a configured data directory, set `CP2K_DATA_DIR` to the CP2K `data`
+directory before running.
+
+The complete examples in `runnable/` are curated derived inputs. Each file header lists the
+paper snippets it is based on; the raw extracted snippets remain unchanged in `paper-snippets/`.
+
+See `runnable/README.md` for the full runnable-example table and local test results.

--- a/cp2k-made-simple/manifest.tsv
+++ b/cp2k-made-simple/manifest.tsv
@@ -1,0 +1,92 @@
+file	section	status	notes
+001-2-total-energy-and-force-methods-force-eval.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.1 Basis Set Convergence using the Quickstep Method	fragment	-
+002-2-total-energy-and-force-methods-force-eval.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.2 Pseudopotentials and Basis Sets	fragment	-
+003-2-total-energy-and-force-methods-qs.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.3 All-Electron Calculations using the GAPW Method	fragment	-
+004-2-total-energy-and-force-methods-kind-o.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.3 All-Electron Calculations using the GAPW Method	fragment	-
+005-2-total-energy-and-force-methods-qs.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.4 Wavefunction Optimization	fragment	-
+006-2-total-energy-and-force-methods-ot.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.4 Wavefunction Optimization	fragment	-
+007-2-total-energy-and-force-methods-dft.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.5 Brillouin-Zone Sampling using k-Points	fragment	requires surrounding input
+008-2-total-energy-and-force-methods-print.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.5 Brillouin-Zone Sampling using k-Points	fragment	-
+009-2-total-energy-and-force-methods-xc.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory	fragment	-
+010-2-total-energy-and-force-methods-xc.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory	fragment	-
+011-2-total-energy-and-force-methods-interaction-potential.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory	fragment	-
+012-2-total-energy-and-force-methods-auxiliary-density-matrix-method.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory > 2.2.1 Auxiliary Density Matrix Method	fragment	-
+013-2-total-energy-and-force-methods-dft.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory > 2.2.1 Auxiliary Density Matrix Method	fragment	requires surrounding input
+014-2-total-energy-and-force-methods-ri.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory > 2.2.2 Resolution-of-the-identity Hartree-Fock Exchange	fragment	-
+015-2-total-energy-and-force-methods-dft.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory > 2.2.2 Resolution-of-the-identity Hartree-Fock Exchange	fragment	requires surrounding input
+016-2-total-energy-and-force-methods-ri-mp2.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.3 Post-Hartree-Fock and Double-Hybrid Density Functional Theory > 2.3.1 Second-order Moller-Plesset Perturbation Theory	fragment	-
+017-2-total-energy-and-force-methods-canonical-gradients.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.3 Post-Hartree-Fock and Double-Hybrid Density Functional Theory > 2.3.1 Second-order Moller-Plesset Perturbation Theory	fragment	-
+018-2-total-energy-and-force-methods-ri-rpa.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.3 Post-Hartree-Fock and Double-Hybrid Density Functional Theory > 2.3.2 Random Phase Approximation and Laplace-transformed Scaled Opposite-spin Second-order Moller-Plesset Perturbation Theory	fragment	-
+019-2-total-energy-and-force-methods-ri-sos-mp2.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.3 Post-Hartree-Fock and Double-Hybrid Density Functional Theory > 2.3.2 Random Phase Approximation and Laplace-transformed Scaled Opposite-spin Second-order Moller-Plesset Perturbation Theory	fragment	-
+020-2-total-energy-and-force-methods-ri-rpa.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.3 Post-Hartree-Fock and Double-Hybrid Density Functional Theory > 2.3.2 Random Phase Approximation and Laplace-transformed Scaled Opposite-spin Second-order Moller-Plesset Perturbation Theory	fragment	contains placeholders
+021-2-total-energy-and-force-methods-wf-correlation.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.3 Post-Hartree-Fock and Double-Hybrid Density Functional Theory > 2.3.3 Low-scaling post-Hartree-Fock	fragment	-
+022-2-total-energy-and-force-methods-force-eval.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.4 Density Functional Theory plus Hubbard U	fragment	contains placeholders
+023-2-total-energy-and-force-methods-kind-u-a.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.4 Density Functional Theory plus Hubbard U	fragment	contains placeholders
+024-2-total-energy-and-force-methods-kind-u-a.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.4 Density Functional Theory plus Hubbard U	fragment	contains placeholders
+025-2-total-energy-and-force-methods-kind-o.inp	The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.4 Density Functional Theory plus Hubbard U	fragment	-
+026-3-electronic-band-structure-force-eval.inp	The CP2K Program Package Made Simple > 3 Electronic Band Structure > 3.1 SIRIUS	fragment	-
+027-3-electronic-band-structure-force-eval.inp	The CP2K Program Package Made Simple > 3 Electronic Band Structure > 3.1 SIRIUS	fragment	-
+028-3-electronic-band-structure-xc.inp	The CP2K Program Package Made Simple > 3 Electronic Band Structure > 3.2 The GW Method > 3.2.3 GW for Molecules	fragment	-
+030-3-electronic-band-structure-dft.inp	The CP2K Program Package Made Simple > 3 Electronic Band Structure > 3.2 The GW Method > 3.2.4 GW for Small Unit Cells with k-point Sampling	fragment	contains placeholders
+031-3-electronic-band-structure-properties.inp	The CP2K Program Package Made Simple > 3 Electronic Band Structure > 3.2 The GW Method > 3.2.4 GW for Small Unit Cells with k-point Sampling	fragment	-
+032-4-embedding-methods-dft.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.1 Implicit Solvation Methods	fragment	contains placeholders
+033-4-embedding-methods-dft.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.1 Implicit Solvation Methods	fragment	contains placeholders
+034-4-embedding-methods-subsys.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.1 Implicit Solvation Methods	fragment	contains placeholders
+035-4-embedding-methods-print.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.1 Implicit Solvation Methods	fragment	contains placeholders
+036-4-embedding-methods-force-eval.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods	fragment	contains placeholders
+037-4-embedding-methods-qmmm.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods > 4.2.1 Electrostatic Embedding by the Gaussian Expansion of the Electrostatic Potential Method	fragment	-
+038-4-embedding-methods-qmmm.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods > 4.2.1 Electrostatic Embedding by the Gaussian Expansion of the Electrostatic Potential Method	fragment	-
+039-4-embedding-methods-qmmm.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods > 4.2.2 Image-charge Augmented Quantum Mechanics/Molecular Mechanics Method	fragment	contains placeholders
+040-4-embedding-methods-properties.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods > 4.2.3 Partial Atomic Charges from Restrained Electrostatic Potential Fitting	fragment	-
+041-4-embedding-methods-resp.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods > 4.2.3 Partial Atomic Charges from Restrained Electrostatic Potential Fitting	fragment	contains placeholders
+042-4-embedding-methods-constraint.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods > 4.2.3 Partial Atomic Charges from Restrained Electrostatic Potential Fitting	fragment	-
+043-4-embedding-methods-multiple-force-evals.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation	fragment	-
+044-4-embedding-methods-force-eval.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation	fragment	contains placeholders
+045-4-embedding-methods-cluster-embed-subsys-true.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation	fragment	keyword-only snippet
+046-4-embedding-methods-ref-embed-subsys-true.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation	fragment	keyword-only snippet
+047-4-embedding-methods-opt-embed.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation	fragment	contains placeholders
+048-4-embedding-methods-high-level-embed-subsys-true.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation	fragment	keyword-only snippet
+049-4-embedding-methods-qs.inp	The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation	fragment	contains placeholders
+050-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-global.inp	The CP2K Program Package Made Simple > 5 Nuclear Magnetic and Electron Paramagnetic Resonance Spectroscopy > 5.1 Density Functional Perturbation Theory	fragment	contains placeholders
+051-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-selected-states-on-atom-list.inp	The CP2K Program Package Made Simple > 5 Nuclear Magnetic and Electron Paramagnetic Resonance Spectroscopy > 5.2 The Magnetic Shielding Tensor	fragment	keyword-only snippet
+052-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-subsys.inp	The CP2K Program Package Made Simple > 5 Nuclear Magnetic and Electron Paramagnetic Resonance Spectroscopy > 5.2 The Magnetic Shielding Tensor	fragment	-
+053-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-localize.inp	The CP2K Program Package Made Simple > 5 Nuclear Magnetic and Electron Paramagnetic Resonance Spectroscopy > 5.2 The Magnetic Shielding Tensor	fragment	-
+054-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-linres-epr-print-g-tensor.inp	The CP2K Program Package Made Simple > 5 Nuclear Magnetic and Electron Paramagnetic Resonance Spectroscopy > 5.3 The Electron Paramagnetic Resonance g-tensor	fragment	-
+055-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-dft-print-hyperfine-coupling-tensor.inp	The CP2K Program Package Made Simple > 5 Nuclear Magnetic and Electron Paramagnetic Resonance Spectroscopy > 5.4 Hyperfine Couplings	fragment	-
+056-6-optical-spectroscopy-tddfpt.inp	The CP2K Program Package Made Simple > 6 Optical Spectroscopy > 6.1 Linear-Response Time-Dependent Density Functional Theory	fragment	-
+057-6-optical-spectroscopy-stda.inp	The CP2K Program Package Made Simple > 6 Optical Spectroscopy > 6.1 Linear-Response Time-Dependent Density Functional Theory	fragment	keyword-only snippet
+058-6-optical-spectroscopy-dft.inp	The CP2K Program Package Made Simple > 6 Optical Spectroscopy > 6.1 Linear-Response Time-Dependent Density Functional Theory	fragment	-
+059-6-optical-spectroscopy-print.inp	The CP2K Program Package Made Simple > 6 Optical Spectroscopy > 6.1 Linear-Response Time-Dependent Density Functional Theory	fragment	-
+060-6-optical-spectroscopy-gw.inp	The CP2K Program Package Made Simple > 6 Optical Spectroscopy > 6.2 Bethe-Salpeter Equation > 6.2.2 Optical absorption spectrum	fragment	-
+061-7-excited-state-dynamics-real-time-propagation.inp	The CP2K Program Package Made Simple > 7 Excited State Dynamics > 7.2 Real-Time Bethe Salpeter Propagation	fragment	-
+062-7-excited-state-dynamics-force-eval.inp	The CP2K Program Package Made Simple > 7 Excited State Dynamics > 7.3 Surface Hopping via NEWTON-X	fragment	contains placeholders
+063-7-excited-state-dynamics-vibrational-analysis.inp	The CP2K Program Package Made Simple > 7 Excited State Dynamics > 7.3 Surface Hopping via NEWTON-X	fragment	-
+064-8-x-ray-spectroscopy-xas.inp	The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.1 Transition Potential Method	fragment	contains placeholders
+065-8-x-ray-spectroscopy-donor-states.inp	The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.2 Linear-Response Time-Dependent Density Functional Theory	fragment	-
+066-8-x-ray-spectroscopy-kernel.inp	The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.2 Linear-Response Time-Dependent Density Functional Theory	fragment	-
+067-8-x-ray-spectroscopy-grid-o-100-250.inp	The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.2 Linear-Response Time-Dependent Density Functional Theory	fragment	keyword-only snippet
+068-8-x-ray-spectroscopy-spin-orbit-coupling.inp	The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.2 Linear-Response Time-Dependent Density Functional Theory	fragment	keyword-only snippet
+069-8-x-ray-spectroscopy-real-time-propagation.inp	The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.3 Real-Time Time-Dependent Density Functional Theory	fragment	-
+070-8-x-ray-spectroscopy-real-time-propagation.inp	The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.3 Real-Time Time-Dependent Density Functional Theory	fragment	-
+071-9-energy-decomposition-analysis-subsys.inp	The CP2K Program Package Made Simple > 9 Energy Decomposition Analysis > 9.1 Implementation	fragment	-
+072-9-energy-decomposition-analysis-subsys.inp	The CP2K Program Package Made Simple > 9 Energy Decomposition Analysis > 9.1 Implementation	fragment	contains placeholders
+073-9-energy-decomposition-analysis-qs.inp	The CP2K Program Package Made Simple > 9 Energy Decomposition Analysis > 9.1 Implementation	fragment	-
+074-10-finite-temperature-effects-force-eval.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.1 Neural Network and Machine Learning Interaction Potentials	fragment	-
+075-10-finite-temperature-effects-force-eval.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.1 Neural Network and Machine Learning Interaction Potentials	fragment	-
+076-10-finite-temperature-effects-print.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.1 Neural Network and Machine Learning Interaction Potentials	fragment	-
+077-10-finite-temperature-effects-bias.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.1 Neural Network and Machine Learning Interaction Potentials	fragment	-
+078-10-finite-temperature-effects-pint.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.2 Nuclear Quantum Effects	fragment	-
+079-10-finite-temperature-effects-nose.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.2 Nuclear Quantum Effects	fragment	-
+080-10-finite-temperature-effects-pile.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.2 Nuclear Quantum Effects	fragment	-
+081-10-finite-temperature-effects-qtb.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.3 Quantum Convergence	fragment	-
+082-10-finite-temperature-effects-pint.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.4 Approximate Quantum Dynamics	fragment	-
+083-10-finite-temperature-effects-helium.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.5 Bosonic Quantum Solvation at Ultra-low Temperatures	fragment	contains placeholders
+084-10-finite-temperature-effects-motion.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.5 Bosonic Quantum Solvation at Ultra-low Temperatures	fragment	-
+085-10-finite-temperature-effects-motion.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.5 Bosonic Quantum Solvation at Ultra-low Temperatures	fragment	-
+086-10-finite-temperature-effects-global.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.1 Static-Harmonic Approach	fragment	-
+087-10-finite-temperature-effects-force-eval.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.3 Computing Electromagnetic Moments	fragment	-
+088-10-finite-temperature-effects-force-eval.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.5 Orbital Localization	fragment	-
+089-10-finite-temperature-effects-dft.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.6 Voronoi Integration	fragment	-
+090-10-finite-temperature-effects-force-eval.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.7 Polarizabilities	fragment	-
+091-10-finite-temperature-effects-force-eval.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.7 Polarizabilities	fragment	-
+092-10-finite-temperature-effects-dft.inp	The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.9 Supported Types of Spectra > Storing Compressed Density Cubes:	fragment	-

--- a/cp2k-made-simple/paper-snippets/001-2-total-energy-and-force-methods-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/001-2-total-energy-and-force-methods-force-eval.inp
@@ -1,0 +1,19 @@
+! CP2K Made Simple paper snippet 001
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.1 Basis Set Convergence using the Quickstep Method
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  METHOD QUICKSTEP
+  &DFT
+    &QS
+      METHOD GPW
+    &END QS
+    &MGRID
+      CUTOFF 400
+      REL_CUTOFF 50
+      NGRIDS 5
+      PROGRESSION_FACTOR 3.0
+    &END MGRID
+  &END DFT
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/002-2-total-energy-and-force-methods-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/002-2-total-energy-and-force-methods-force-eval.inp
@@ -1,0 +1,17 @@
+! CP2K Made Simple paper snippet 002
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.2 Pseudopotentials and Basis Sets
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_MOLOPT_UZH
+    POTENTIAL_FILE_NAME POTENTIAL_UZH
+  &END DFT
+  &SUBSYS
+    &KIND Au
+      BASIS_SET TZV2P-MOLOPT-GGA-GTH-q19
+      POTENTIAL GTH-GGA-q19
+    &END KIND
+  &SUBSYS
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/003-2-total-energy-and-force-methods-qs.inp
+++ b/cp2k-made-simple/paper-snippets/003-2-total-energy-and-force-methods-qs.inp
@@ -1,0 +1,11 @@
+! CP2K Made Simple paper snippet 003
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.3 All-Electron Calculations using the GAPW Method
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&QS
+  METHOD GAPW
+  EPSFIT 1.0E-6
+  EPSRHO0 1.0E-8
+  EPSSVD 1.0E-12
+&END QS

--- a/cp2k-made-simple/paper-snippets/004-2-total-energy-and-force-methods-kind-o.inp
+++ b/cp2k-made-simple/paper-snippets/004-2-total-energy-and-force-methods-kind-o.inp
@@ -1,0 +1,11 @@
+! CP2K Made Simple paper snippet 004
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.3 All-Electron Calculations using the GAPW Method
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&KIND O
+  BASIS_SET ORB TZVPP-MOLOPT-GGA-ae
+  POTENTIAL ALL
+  LEBEDEV_GRID 400
+  RADIAL_GRID 100
+&END KIND

--- a/cp2k-made-simple/paper-snippets/005-2-total-energy-and-force-methods-qs.inp
+++ b/cp2k-made-simple/paper-snippets/005-2-total-energy-and-force-methods-qs.inp
@@ -1,0 +1,24 @@
+! CP2K Made Simple paper snippet 005
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.4 Wavefunction Optimization
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&QS
+  EPS_DEFAULT 1.0E-12
+&END QS
+&SCF
+  MAX_SCF 100
+  EPS_SCF 1.0E-6
+  SCF_GUESS RESTART
+  ADDED_MOS 10
+  &MIXING
+    METHOD BROYDEN_MIXING
+    ALPHA 0.2
+    BETA 0.8
+    NBROYDEN 10
+  &END MIXING
+  &SMEAR
+    METHOD FERMI_DIRAC
+    ELECTRONIC_TEMPERATURE [K] 300
+  &END SMEAR
+&END SCF

--- a/cp2k-made-simple/paper-snippets/006-2-total-energy-and-force-methods-ot.inp
+++ b/cp2k-made-simple/paper-snippets/006-2-total-energy-and-force-methods-ot.inp
@@ -1,0 +1,16 @@
+! CP2K Made Simple paper snippet 006
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.4 Wavefunction Optimization
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&OT
+  MINIMIZER DIIS
+  SAFE_DIIS TRUE
+  PRECONDITIONER FULL_ALL
+  ENERGY_GAP 0.0001
+  STEPSIZE 0.1
+&END OT
+&OUTER_SCF
+  EPS_SCF 1.0E-7
+  MAX_SCF 10
+&END OUTER_SCF

--- a/cp2k-made-simple/paper-snippets/007-2-total-energy-and-force-methods-dft.inp
+++ b/cp2k-made-simple/paper-snippets/007-2-total-energy-and-force-methods-dft.inp
@@ -1,0 +1,11 @@
+! CP2K Made Simple paper snippet 007
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.5 Brillouin-Zone Sampling using k-Points
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&DFT
+  &KPOINTS
+    SCHEME MONKHORST-PACK 8 8 4
+  &END KPOINTS
+  # Rest of the DFT input
+&END DFT

--- a/cp2k-made-simple/paper-snippets/008-2-total-energy-and-force-methods-print.inp
+++ b/cp2k-made-simple/paper-snippets/008-2-total-energy-and-force-methods-print.inp
@@ -1,0 +1,22 @@
+! CP2K Made Simple paper snippet 008
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.1 Density Functional Theory > 2.1.5 Brillouin-Zone Sampling using k-Points
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&PRINT
+  &BAND_STRUCTURE
+    # Output file:
+    FILE_NAME graphene.bs
+    # Number of empty bands:
+    ADDED_MOS 2
+    # Specifying the band path:
+    &KPOINT_SET
+      NPOINTS 10
+      UNITS B_VECTOR
+      SPECIAL_POINT G 0.0 0.0 0.0
+      SPECIAL_POINT K 1/3 1/3 0.0
+      SPECIAL_POINT M 1/2 0.0 0.0
+      SPECIAL_POINT G 0.0 0.0 0.0
+    &END KPOINT_SET
+  &END BAND_STRUCTURE
+&END PRINT

--- a/cp2k-made-simple/paper-snippets/009-2-total-energy-and-force-methods-xc.inp
+++ b/cp2k-made-simple/paper-snippets/009-2-total-energy-and-force-methods-xc.inp
@@ -1,0 +1,13 @@
+! CP2K Made Simple paper snippet 009
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&XC
+  &XC_FUNCTIONAL NONE
+  &END XC_FUNCTIONAL
+  &HF
+    FRACTION 1.0
+    # Additional HF inputs below
+  &END HF
+&END XC

--- a/cp2k-made-simple/paper-snippets/010-2-total-energy-and-force-methods-xc.inp
+++ b/cp2k-made-simple/paper-snippets/010-2-total-energy-and-force-methods-xc.inp
@@ -1,0 +1,18 @@
+! CP2K Made Simple paper snippet 010
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&XC
+  &XC_FUNCTIONAL
+    &GGA_C_PBE
+    &END GGA_C_PBE
+    &GGA_X_PBE
+      SCALE 0.75
+    &END GGA_X_PBE
+  &END XC_FUNCTIONAL
+  &HF
+    FRACTION 0.25
+    # Additional HF inputs below
+  &END HF
+&END XC

--- a/cp2k-made-simple/paper-snippets/011-2-total-energy-and-force-methods-interaction-potential.inp
+++ b/cp2k-made-simple/paper-snippets/011-2-total-energy-and-force-methods-interaction-potential.inp
@@ -1,0 +1,14 @@
+! CP2K Made Simple paper snippet 011
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&INTERACTION_POTENTIAL
+  ! Should be <= than L/2 but large
+  ! enough for the erf to decay
+  CUTOFF_RADIUS 6.0
+  OMEGA 0.33
+  POTENTIAL_TYPE MIX_CL_TRUNC
+  SCALE_COULOMB 0.18352
+  SCALE_LONGRANGE 0.94979
+&END INTERACTION_POTENTIAL

--- a/cp2k-made-simple/paper-snippets/012-2-total-energy-and-force-methods-auxiliary-density-matrix-method.inp
+++ b/cp2k-made-simple/paper-snippets/012-2-total-energy-and-force-methods-auxiliary-density-matrix-method.inp
@@ -1,0 +1,11 @@
+! CP2K Made Simple paper snippet 012
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory > 2.2.1 Auxiliary Density Matrix Method
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&AUXILIARY_DENSITY_MATRIX_METHOD
+  # Choose between ADMM flavors
+  ADMM_TYPE ADMMS
+  # Use PBE exchange (example)
+  EXCH_CORRECTION_FUNC PBEX
+&END AUXILIARY_DENSITY_MATRIX_METHOD

--- a/cp2k-made-simple/paper-snippets/013-2-total-energy-and-force-methods-dft.inp
+++ b/cp2k-made-simple/paper-snippets/013-2-total-energy-and-force-methods-dft.inp
@@ -1,0 +1,19 @@
+! CP2K Made Simple paper snippet 013
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory > 2.2.1 Auxiliary Density Matrix Method
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&DFT
+  BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+  BASIS_SET_FILE_NAME BASIS_ADMM_UZH
+  POTENTIAL_FILE_NAME POTENTIAL_UZH
+  # Rest of DFT input
+&END DFT
+&SUBSYS
+  &KIND O
+    BASIS_SET ccGRB-D-q6
+    BASIS_SET AUX_FIT admm-dz-q6
+    POTENTIAL GTH-HYB-q6
+  &END KIND
+  # Rest of SUBSYS input
+&END SUBSYS

--- a/cp2k-made-simple/paper-snippets/014-2-total-energy-and-force-methods-ri.inp
+++ b/cp2k-made-simple/paper-snippets/014-2-total-energy-and-force-methods-ri.inp
@@ -1,0 +1,15 @@
+! CP2K Made Simple paper snippet 014
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory > 2.2.2 Resolution-of-the-identity Hartree-Fock Exchange
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&RI
+  # Definition of the RI metric:
+  RI_METRIC TRUNCATED
+  CUTOFF_RADIUS 2.0
+  # Optional but potentially
+  # important keywords, here
+  # with default values
+  MEMORY_CUT 3
+  EPS_FILTER 1.0E-9
+&END RI

--- a/cp2k-made-simple/paper-snippets/015-2-total-energy-and-force-methods-dft.inp
+++ b/cp2k-made-simple/paper-snippets/015-2-total-energy-and-force-methods-dft.inp
@@ -1,0 +1,20 @@
+! CP2K Made Simple paper snippet 015
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.2 Hartree-Fock and Hybrid Density Functional Theory > 2.2.2 Resolution-of-the-identity Hartree-Fock Exchange
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&DFT
+  SORT_BASIS EXP
+  # Rest of the DFT input
+&END DFT
+&SUBSYS
+  &KIND
+    BASIS_SET cc-pVTZ
+    # If the following line is not
+    # present, the RI_HFX basis is
+    # generated on-the-fly
+    BASIS_SET RI_HFX cc-pVTZ-JKFIT
+    POTENTIAL ALL
+  &END KIND
+  # Rest of the SUBSYS input
+&EBD SUBSYS

--- a/cp2k-made-simple/paper-snippets/016-2-total-energy-and-force-methods-ri-mp2.inp
+++ b/cp2k-made-simple/paper-snippets/016-2-total-energy-and-force-methods-ri-mp2.inp
@@ -1,0 +1,15 @@
+! CP2K Made Simple paper snippet 016
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.3 Post-Hartree-Fock and Double-Hybrid Density Functional Theory > 2.3.1 Second-order Moller-Plesset Perturbation Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&RI_MP2
+  # Larger block sizes require more
+  # memory but reduce communication,
+  # (default: -1, auto determination)
+  BLOCK_SIZE 2
+  # Large number of groups increase the
+  # memory demands but reduce communication
+  # (default: -1, auto determination)
+  NUMBER_INTEGRATION_GROUPS 2
+&END

--- a/cp2k-made-simple/paper-snippets/017-2-total-energy-and-force-methods-canonical-gradients.inp
+++ b/cp2k-made-simple/paper-snippets/017-2-total-energy-and-force-methods-canonical-gradients.inp
@@ -1,0 +1,19 @@
+! CP2K Made Simple paper snippet 017
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.3 Post-Hartree-Fock and Double-Hybrid Density Functional Theory > 2.3.1 Second-order Moller-Plesset Perturbation Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&CANONICAL_GRADIENTS
+  # The default is usually good enough
+  EPS_CANONICAL 1E-6
+  # This option which should always work
+  # Try to set it to .TRUE.
+  FREE_HFX_BUFFER .FALSE.
+  &CPHF
+    # Choose as tight as necessary
+    EPS_CONV 1.0E-6
+    # Smaller values of EPS_CONV
+    # may require more iterations
+    MAX_ITER 10
+  &END CPHF
+&END CANONICAL_GRADIENTS

--- a/cp2k-made-simple/paper-snippets/018-2-total-energy-and-force-methods-ri-rpa.inp
+++ b/cp2k-made-simple/paper-snippets/018-2-total-energy-and-force-methods-ri-rpa.inp
@@ -1,0 +1,16 @@
+! CP2K Made Simple paper snippet 018
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.3 Post-Hartree-Fock and Double-Hybrid Density Functional Theory > 2.3.2 Random Phase Approximation and Laplace-transformed Scaled Opposite-spin Second-order Moller-Plesset Perturbation Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&RI_RPA
+  # Switch to the Minimax quadrature
+  # rules (default: turned off, use
+  # Clenshaw-Curtis-quadrature)
+  MINIMAX .TRUE.
+  # Choose it as large as necessary
+  # and as small as possible
+  QUADRATURE_POINTS 6
+  # Fine-tuning of the parallelization
+  NUM_INTEG_GROUPS -1
+&END

--- a/cp2k-made-simple/paper-snippets/019-2-total-energy-and-force-methods-ri-sos-mp2.inp
+++ b/cp2k-made-simple/paper-snippets/019-2-total-energy-and-force-methods-ri-sos-mp2.inp
@@ -1,0 +1,10 @@
+! CP2K Made Simple paper snippet 019
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.3 Post-Hartree-Fock and Double-Hybrid Density Functional Theory > 2.3.2 Random Phase Approximation and Laplace-transformed Scaled Opposite-spin Second-order Moller-Plesset Perturbation Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&RI_SOS_MP2
+  # Both parameters work similarly to RPA
+  QUADRATURE_POINTS 6
+  NUM_INTEG_GROUPS -1
+&END

--- a/cp2k-made-simple/paper-snippets/020-2-total-energy-and-force-methods-ri-rpa.inp
+++ b/cp2k-made-simple/paper-snippets/020-2-total-energy-and-force-methods-ri-rpa.inp
@@ -1,0 +1,34 @@
+! CP2K Made Simple paper snippet 020
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.3 Post-Hartree-Fock and Double-Hybrid Density Functional Theory > 2.3.2 Random Phase Approximation and Laplace-transformed Scaled Opposite-spin Second-order Moller-Plesset Perturbation Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&RI_RPA
+  ...
+  # The RSE correction is only relevant
+  # for non-HF reference states
+  RSE .TRUE.
+  # Exchange corrections can be costly
+  &EXCHANGE_CORRECTION [NONE|AXK|SOSEX]
+    # The Hartree-Fock-based implemen-
+    # tation scales better for larger
+    # systems but introduces more noise
+    USE_HFX_IMPLEMENTATION F
+    # This parameter is ignored if
+    # USE_HFX_IMPLEMENTATION is set to T
+    # Larger values improve performance
+    # but increase memory usage
+    BLOCK_SIZE 16
+  &END EXCHANGE_CORRECTION
+  # This HF section activates the exact
+  # exchange correction and is also used
+  # by the RSE and the AXK/SOSEX methods
+  &HF
+    ...
+    &MEMORY
+      # Set to zero if RSE/AXK/SOSEX
+      # are not requested
+      MAX_MEMORY 500
+    &END MEMORY
+  &END HF
+&END

--- a/cp2k-made-simple/paper-snippets/021-2-total-energy-and-force-methods-wf-correlation.inp
+++ b/cp2k-made-simple/paper-snippets/021-2-total-energy-and-force-methods-wf-correlation.inp
@@ -1,0 +1,18 @@
+! CP2K Made Simple paper snippet 021
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.3 Post-Hartree-Fock and Double-Hybrid Density Functional Theory > 2.3.3 Low-scaling post-Hartree-Fock
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&WF_CORRELATION
+  # Usual RI_RPA/RI_SOS_MP2 input here
+  &LOW_SCALING
+    MEMORY_CUT 3
+    EPS_FILTER 1.0E-9
+  &END LOW_SCALING
+  &RI
+    &RI_METRIC
+      POTENTIAL_TYPE TRUNCATED
+      CUTOFF_RADIUS 1.5
+    &END RI_METRIC
+  &END RI
+&END WF_CORRELATION

--- a/cp2k-made-simple/paper-snippets/022-2-total-energy-and-force-methods-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/022-2-total-energy-and-force-methods-force-eval.inp
@@ -1,0 +1,17 @@
+! CP2K Made Simple paper snippet 022
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.4 Density Functional Theory plus Hubbard U
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    PLUS_U_METHOD Mulliken
+    ...
+    &PRINT
+      &PLUS_U on
+      &END PLUS_U
+    &END PRINT
+  &END DFT
+  ...
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/023-2-total-energy-and-force-methods-kind-u-a.inp
+++ b/cp2k-made-simple/paper-snippets/023-2-total-energy-and-force-methods-kind-u-a.inp
@@ -1,0 +1,18 @@
+! CP2K Made Simple paper snippet 023
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.4 Density Functional Theory plus Hubbard U
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&KIND U_a
+  ...
+  &DFT_PLUS_U on
+    L 3
+    U_MINUS_J [eV] 2.0
+    &ENFORCE_OCCUPATION on
+      EPS_SCF 1.0E-3
+      MAX_SCF 20
+      ORBITALS -3 -1
+      SMEAR on
+    &END ENFORCE_OCCUPATION
+  &END DFT_PLUS_U
+&END KIND

--- a/cp2k-made-simple/paper-snippets/024-2-total-energy-and-force-methods-kind-u-a.inp
+++ b/cp2k-made-simple/paper-snippets/024-2-total-energy-and-force-methods-kind-u-a.inp
@@ -1,0 +1,23 @@
+! CP2K Made Simple paper snippet 024
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.4 Density Functional Theory plus Hubbard U
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&KIND U_a
+  ...
+  &BS
+    # U(+4): 5f3 6d1 7s2 -> 5f2 6d0 7s0
+    &ALPHA
+      N    5  6  7 # 5       6       7
+      L    3  2  0 # f       d       s
+      NEL +1 -1 -2 # (3+1)/2 (1-1)/2 (2-2)/2
+      # U(alpha)   : 2       0       0
+    &END ALPHA
+    &BETA
+      N    5  6  7 # 5       6       7
+      L    3  2  0 # f       d       s
+      NEL -3 -1 -2 # (3-3)/2 (1-1)/2 (2-2)/2
+      # U(beta)    : 0       0       0
+    &END BETA
+  &END BS
+&END KIND

--- a/cp2k-made-simple/paper-snippets/025-2-total-energy-and-force-methods-kind-o.inp
+++ b/cp2k-made-simple/paper-snippets/025-2-total-energy-and-force-methods-kind-o.inp
@@ -1,0 +1,21 @@
+! CP2K Made Simple paper snippet 025
+! Section: The CP2K Program Package Made Simple > 2 Total Energy and Force Methods > 2.4 Density Functional Theory plus Hubbard U
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&KIND O
+  &BS
+    # O(-2): 2s2 2p4 -> 2s2 2p6
+    &ALPHA
+      N    2    # 2
+      L    1    # p
+      NEL +2    # (4+2)/2
+      # O(alpha): 3
+    &END ALPHA
+    &BETA
+      N    2    # 2
+      L    1    # p
+      NEL +2    # (4+2)/2
+      # O(beta) : 3
+    &END BETA
+   &END BS

--- a/cp2k-made-simple/paper-snippets/026-3-electronic-band-structure-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/026-3-electronic-band-structure-force-eval.inp
@@ -1,0 +1,29 @@
+! CP2K Made Simple paper snippet 026
+! Section: The CP2K Program Package Made Simple > 3 Electronic Band Structure > 3.1 SIRIUS
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  METHOD SIRIUS
+  &PW_DFT
+    &MIXER
+      BETA 0.5
+      USE_HARTREE .TRUE.
+    &END MIXER
+    &PARAMETERS
+    ELECTRONIC_STRUCTURE_METHOD \
+      PSEUDOPOTENTIAL
+    GK_CUTOFF 5
+    PW_CUTOFF 20
+    NGRIDK 4 4 4
+    SMEARING GAUSSIAN
+    SMEARING_WIDTH 0.0004
+  &END PARAMETERS
+  &END PW_DFT
+  &SUBSYS
+    &KIND C
+      POTENTIAL UPF \
+        C.pbe-n-kjpaw_psl.1.0.0.UPF
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/027-3-electronic-band-structure-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/027-3-electronic-band-structure-force-eval.inp
@@ -1,0 +1,32 @@
+! CP2K Made Simple paper snippet 027
+! Section: The CP2K Program Package Made Simple > 3 Electronic Band Structure > 3.1 SIRIUS
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  METHOD SIRIUS
+  &PW_DFT
+    &PARAMETERS
+      ELECTRONIC_STRUCTURE_METHOD \
+        FULL_POTENTIAL_LAPWLO
+      DENSITY_TOL 1e-06
+      ENERGY_TOL 1e-10
+      GK_CUTOFF 4.0
+      NGRIDK 4 4 4
+      PW_CUTOFF 20
+      SMEARING GAUSSIAN
+      SMEARING_WIDTH 0.0004
+      AUTO_RMT 1
+      CORE_RELATIVITY DIRAC
+      VALENCE_RELATIVITY IORA
+      LMAX_APW 12
+      LMAX_POT 12
+      LMAX_RHO 12
+    &END PARAMETERS
+  &END PW_DFT
+  &SUBSYS
+    &KIND C
+      POTENTIAL UPF C.json
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/028-3-electronic-band-structure-xc.inp
+++ b/cp2k-made-simple/paper-snippets/028-3-electronic-band-structure-xc.inp
@@ -1,0 +1,18 @@
+! CP2K Made Simple paper snippet 028
+! Section: The CP2K Program Package Made Simple > 3 Electronic Band Structure > 3.2 The GW Method > 3.2.3 GW for Molecules
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&XC
+  &XC_FUNCTIONAL PBE
+  &END XC_FUNCTIONAL
+  &WF_CORRELATION
+    &RI_RPA
+      QUADRATURE_POINTS 100
+      &GW
+        ! Also possible: EV_GW0 or EV_GW
+        SELF_CONSISTENCY G0W0
+      &END GW
+    &END RI_RPA
+  &END WF_CORRELATION
+&END XC

--- a/cp2k-made-simple/paper-snippets/030-3-electronic-band-structure-dft.inp
+++ b/cp2k-made-simple/paper-snippets/030-3-electronic-band-structure-dft.inp
@@ -1,0 +1,12 @@
+! CP2K Made Simple paper snippet 030
+! Section: The CP2K Program Package Made Simple > 3 Electronic Band Structure > 3.2 The GW Method > 3.2.4 GW for Small Unit Cells with k-point Sampling
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&DFT
+  ...
+  &KPOINTS
+    SCHEME MONKHORST-PACK 32 32 1
+    PARALLEL_GROUP_SIZE -1
+  &END KPOINTS
+&END DFT

--- a/cp2k-made-simple/paper-snippets/031-3-electronic-band-structure-properties.inp
+++ b/cp2k-made-simple/paper-snippets/031-3-electronic-band-structure-properties.inp
@@ -1,0 +1,24 @@
+! CP2K Made Simple paper snippet 031
+! Section: The CP2K Program Package Made Simple > 3 Electronic Band Structure > 3.2 The GW Method > 3.2.4 GW for Small Unit Cells with k-point Sampling
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&PROPERTIES
+  &BANDSTRUCTURE
+    &GW
+      NUM_TIME_FREQ_POINTS      30
+      MEMORY_PER_PROC           10
+      EPS_FILTER           1.0E-11
+      REGULARIZATION_RI     1.0E-2
+      CUTOFF_RADIUS_RI         7.0
+    &END GW
+    &SOC
+    &END SOC
+    &BANDSTRUCTURE_PATH
+      NPOINTS 19
+      SPECIAL_POINT K     1/3 1/3 0.0
+      SPECIAL_POINT GAMMA 0.0 0.0 0.0
+      SPECIAL_POINT M     0.0 0.5 0.0
+    &END BANDSTRUCTURE_PATH
+  &END BANDSTRUCTURE
+&END PROPERTIES

--- a/cp2k-made-simple/paper-snippets/032-4-embedding-methods-dft.inp
+++ b/cp2k-made-simple/paper-snippets/032-4-embedding-methods-dft.inp
@@ -1,0 +1,29 @@
+! CP2K Made Simple paper snippet 032
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.1 Implicit Solvation Methods
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&DFT
+  &SCCS on
+    ALPHA [mN/m] 50.0
+    BETA [GPa] -0.35
+    DELTA_RHO 2.0E-5
+    DERIVATIVE_METHOD CD5 # or FFT
+    DIELECTRIC_CONSTANT 78.36
+    EPS_SCCS 1.0E-9
+    GAMMA [mN/m] 0.0
+    EPS_SCF 1.0E-3
+    MAX_ITER 100
+    METHOD Andreussi # or Fatteberg-Gygi
+    MIXING 0.6
+    &ANDREUSSI
+      RHO_MAX 0.005
+      RHO_MIN 0.0001
+    &END ANDREUSSI
+    &FATTEBERT-GYGI
+      BETA 1.7
+      RHO_ZERO 6.0E-4
+    &END FATTEBERT-GYGI
+  &END SCCS
+  ...
+&END DFT

--- a/cp2k-made-simple/paper-snippets/033-4-embedding-methods-dft.inp
+++ b/cp2k-made-simple/paper-snippets/033-4-embedding-methods-dft.inp
@@ -1,0 +1,12 @@
+! CP2K Made Simple paper snippet 033
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.1 Implicit Solvation Methods
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&DFT
+  &POISSON
+    PERIODIC none
+    POISSON_SOLVER MT
+  &END POISSON
+  ...
+&END DFT

--- a/cp2k-made-simple/paper-snippets/034-4-embedding-methods-subsys.inp
+++ b/cp2k-made-simple/paper-snippets/034-4-embedding-methods-subsys.inp
@@ -1,0 +1,12 @@
+! CP2K Made Simple paper snippet 034
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.1 Implicit Solvation Methods
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&SUBSYS
+  &CELL
+    PERIODIC none
+    ...
+  &END CELL
+  ...
+&END SUBSYS

--- a/cp2k-made-simple/paper-snippets/035-4-embedding-methods-print.inp
+++ b/cp2k-made-simple/paper-snippets/035-4-embedding-methods-print.inp
@@ -1,0 +1,19 @@
+! CP2K Made Simple paper snippet 035
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.1 Implicit Solvation Methods
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&PRINT
+  &SCCS ON
+    &EACH
+      QS_SCF 0
+    &END EACH
+    &POLARISATION_POTENTIAL off
+      &EACH
+        QS_SCF 0
+      &END EACH
+    &END POLARISATION_POTENTIAL
+    ...
+  &END SCCS
+  ...
+&END PRINT

--- a/cp2k-made-simple/paper-snippets/036-4-embedding-methods-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/036-4-embedding-methods-force-eval.inp
@@ -1,0 +1,23 @@
+! CP2K Made Simple paper snippet 036
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  METHOD QMMM
+  ...
+  &QMMM
+    ECOUPL Coulomb
+    &CELL
+      ABC 25.0 25.0 25.0
+      PERIODIC XYZ
+    &END CELL
+    &QM_KIND C
+      MM_INDEX 1..6
+    &END QM_KIND
+    &PERIODIC
+      &MULTIPOLE OFF
+      &END MULTIPOLE
+    &END PERIODIC
+ &END QMMM
+&FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/037-4-embedding-methods-qmmm.inp
+++ b/cp2k-made-simple/paper-snippets/037-4-embedding-methods-qmmm.inp
@@ -1,0 +1,18 @@
+! CP2K Made Simple paper snippet 037
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods > 4.2.1 Electrostatic Embedding by the Gaussian Expansion of the Electrostatic Potential Method
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&QMMM
+  ECOUPL GAUSS
+  USE_GEEP_LIB 9
+  &MM_KIND H
+    RADIUS 0.44
+  &END MM_KIND
+  &MM_KIND O
+    RADIUS 0.78
+  &END MM_KIND
+  &QM_KIND C
+    MM_INDEX 1..6
+  &END QM_KIND
+&END QMMM

--- a/cp2k-made-simple/paper-snippets/038-4-embedding-methods-qmmm.inp
+++ b/cp2k-made-simple/paper-snippets/038-4-embedding-methods-qmmm.inp
@@ -1,0 +1,19 @@
+! CP2K Made Simple paper snippet 038
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods > 4.2.1 Electrostatic Embedding by the Gaussian Expansion of the Electrostatic Potential Method
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&QMMM
+  ECOUPL GAUSS
+  USE_GEEP_LIB 6
+  &PERIODIC
+    GMAX 0.5
+    NGRIDS  20 20 20
+    REPLICA  2
+    &MULTIPOLE
+      EWALD_PRECISION 0.00000001
+      RCUT 8.0
+      ANALYTICAL_GTERM
+    &END MULTIPOLE
+  &END PERIODIC
+&END QMMM

--- a/cp2k-made-simple/paper-snippets/039-4-embedding-methods-qmmm.inp
+++ b/cp2k-made-simple/paper-snippets/039-4-embedding-methods-qmmm.inp
@@ -1,0 +1,12 @@
+! CP2K Made Simple paper snippet 039
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods > 4.2.2 Image-charge Augmented Quantum Mechanics/Molecular Mechanics Method
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&QMMM
+  ...
+  &IMAGE_CHARGE
+    MM_ATOM_LIST 1..576
+    EXT_POTENTIAL 0.0
+  &END IMAGE_CHARGE
+&END QMMM

--- a/cp2k-made-simple/paper-snippets/040-4-embedding-methods-properties.inp
+++ b/cp2k-made-simple/paper-snippets/040-4-embedding-methods-properties.inp
@@ -1,0 +1,11 @@
+! CP2K Made Simple paper snippet 040
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods > 4.2.3 Partial Atomic Charges from Restrained Electrostatic Potential Fitting
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&PROPERTIES
+  &RESP
+    &SPHERE_SAMPLING
+    &END SPHERE_SAMPLING
+  &END RESP
+&END PROPERTIES

--- a/cp2k-made-simple/paper-snippets/041-4-embedding-methods-resp.inp
+++ b/cp2k-made-simple/paper-snippets/041-4-embedding-methods-resp.inp
@@ -1,0 +1,14 @@
+! CP2K Made Simple paper snippet 041
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods > 4.2.3 Partial Atomic Charges from Restrained Electrostatic Potential Fitting
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+  &RESP
+    ...
+    &RESTRAINT
+      ATOM_LIST 1..3
+      TARGET -0.18
+      STRENGTH 0.0001
+    &END RESTRAINT
+    RESTRAIN_HEAVIES_TO_ZERO .FALSE.
+  &END RESP

--- a/cp2k-made-simple/paper-snippets/042-4-embedding-methods-constraint.inp
+++ b/cp2k-made-simple/paper-snippets/042-4-embedding-methods-constraint.inp
@@ -1,0 +1,9 @@
+! CP2K Made Simple paper snippet 042
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.2 Quantum Mechanics/Molecular Mechanics Methods > 4.2.3 Partial Atomic Charges from Restrained Electrostatic Potential Fitting
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&CONSTRAINT
+  EQUAL_CHARGES
+  ATOM_LIST 1 2 3
+&END

--- a/cp2k-made-simple/paper-snippets/043-4-embedding-methods-multiple-force-evals.inp
+++ b/cp2k-made-simple/paper-snippets/043-4-embedding-methods-multiple-force-evals.inp
@@ -1,0 +1,9 @@
+! CP2K Made Simple paper snippet 043
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&MULTIPLE_FORCE_EVALS
+  FORCE_EVAL_ORDER 2 3 4 5
+  MULTIPLE_SUBSYS T
+&END MULTIPLE_FORCE_EVALS

--- a/cp2k-made-simple/paper-snippets/044-4-embedding-methods-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/044-4-embedding-methods-force-eval.inp
@@ -1,0 +1,48 @@
+! CP2K Made Simple paper snippet 044
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  METHOD EMBED
+  &EMBED
+    &MAPPING
+      &FORCE_EVAL 1
+        &FRAGMENT 1
+          1 3
+          MAP 1
+        &END FRAGMENT
+      &END FORCE_EVAL
+      &FORCE_EVAL 2
+        &FRAGMENT 1
+          1 2
+          MAP 2
+        &END FRAGMENT
+      &END FORCE_EVAL
+      &FORCE_EVAL 3
+        &FRAGMENT 1
+          1 5
+          MAP 3
+        &END FRAGMENT
+      &END FORCE_EVAL
+      &FORCE_EVAL 4
+        &FRAGMENT 1
+          1 2
+          MAP 2
+        &END FRAGMENT
+      &END FORCE_EVAL
+      &FORCE_EVAL_EMBED
+        &FRAGMENT 1
+          1 3
+        &END FRAGMENT
+        &FRAGMENT 2
+          4 5
+        &END FRAGMENT
+        &FRAGMENT 3
+          1 5
+        &END FRAGMENT
+      &END FORCE_EVAL_EMBED
+    &END MAPPING
+  &END EMBED
+  ...
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/045-4-embedding-methods-cluster-embed-subsys-true.inp
+++ b/cp2k-made-simple/paper-snippets/045-4-embedding-methods-cluster-embed-subsys-true.inp
@@ -1,0 +1,6 @@
+! CP2K Made Simple paper snippet 045
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+CLUSTER_EMBED_SUBSYS .TRUE.

--- a/cp2k-made-simple/paper-snippets/046-4-embedding-methods-ref-embed-subsys-true.inp
+++ b/cp2k-made-simple/paper-snippets/046-4-embedding-methods-ref-embed-subsys-true.inp
@@ -1,0 +1,6 @@
+! CP2K Made Simple paper snippet 046
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+  REF_EMBED_SUBSYS .TRUE.

--- a/cp2k-made-simple/paper-snippets/047-4-embedding-methods-opt-embed.inp
+++ b/cp2k-made-simple/paper-snippets/047-4-embedding-methods-opt-embed.inp
@@ -1,0 +1,8 @@
+! CP2K Made Simple paper snippet 047
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&OPT_EMBED
+ ...
+&END OPT_EMBED

--- a/cp2k-made-simple/paper-snippets/048-4-embedding-methods-high-level-embed-subsys-true.inp
+++ b/cp2k-made-simple/paper-snippets/048-4-embedding-methods-high-level-embed-subsys-true.inp
@@ -1,0 +1,6 @@
+! CP2K Made Simple paper snippet 048
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+HIGH_LEVEL_EMBED_SUBSYS .TRUE.

--- a/cp2k-made-simple/paper-snippets/049-4-embedding-methods-qs.inp
+++ b/cp2k-made-simple/paper-snippets/049-4-embedding-methods-qs.inp
@@ -1,0 +1,12 @@
+! CP2K Made Simple paper snippet 049
+! Section: The CP2K Program Package Made Simple > 4 Embedding Methods > 4.3 Density Functional Embedding Theory > 4.3.2 Implementation
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&QS
+  DFET_EMBEDDED .TRUE.
+  EMBED_CUBE_FILE_NAME potential.cube
+  EMBED_SPIN_CUBE_FILE_NAME
+  spin_potential.cube
+  ...
+&END QS

--- a/cp2k-made-simple/paper-snippets/050-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-global.inp
+++ b/cp2k-made-simple/paper-snippets/050-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-global.inp
@@ -1,0 +1,15 @@
+! CP2K Made Simple paper snippet 050
+! Section: The CP2K Program Package Made Simple > 5 Nuclear Magnetic and Electron Paramagnetic Resonance Spectroscopy > 5.1 Density Functional Perturbation Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&GLOBAL
+  RUN_TYPE LINEAR_RESPONSE
+&END GLOBAL
+&FORCE_EVAL
+  &PROPERTIES
+    &LINRES
+      ...
+    &END LINRES
+  &END PROPERTIES
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/051-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-selected-states-on-atom-list.inp
+++ b/cp2k-made-simple/paper-snippets/051-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-selected-states-on-atom-list.inp
@@ -1,0 +1,7 @@
+! CP2K Made Simple paper snippet 051
+! Section: The CP2K Program Package Made Simple > 5 Nuclear Magnetic and Electron Paramagnetic Resonance Spectroscopy > 5.2 The Magnetic Shielding Tensor
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+SELECTED_STATES_ON_ATOM_LIST
+SELECTED_STATES_ATOM_RADIUS

--- a/cp2k-made-simple/paper-snippets/052-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-subsys.inp
+++ b/cp2k-made-simple/paper-snippets/052-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-subsys.inp
@@ -1,0 +1,13 @@
+! CP2K Made Simple paper snippet 052
+! Section: The CP2K Program Package Made Simple > 5 Nuclear Magnetic and Electron Paramagnetic Resonance Spectroscopy > 5.2 The Magnetic Shielding Tensor
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&SUBSYS
+  &KIND H
+    BASIS_SET aug-pcSeg-2
+    POTENTIAL ALL
+    LEBEDEV_GRID 100
+    RADIAL_GRID 200
+  &END KIND
+&END SUBSYS

--- a/cp2k-made-simple/paper-snippets/053-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-localize.inp
+++ b/cp2k-made-simple/paper-snippets/053-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-localize.inp
@@ -1,0 +1,13 @@
+! CP2K Made Simple paper snippet 053
+! Section: The CP2K Program Package Made Simple > 5 Nuclear Magnetic and Electron Paramagnetic Resonance Spectroscopy > 5.2 The Magnetic Shielding Tensor
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&LOCALIZE
+  &NMR
+    NICS .TRUE.
+    NICS_FILE_NAME nics.xyz
+    SHIFT_GAPW_RADIUS # Cutoff current
+                      # integration
+  &END NMR
+&END LOCALIZE

--- a/cp2k-made-simple/paper-snippets/054-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-linres-epr-print-g-tensor.inp
+++ b/cp2k-made-simple/paper-snippets/054-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-linres-epr-print-g-tensor.inp
@@ -1,0 +1,6 @@
+! CP2K Made Simple paper snippet 054
+! Section: The CP2K Program Package Made Simple > 5 Nuclear Magnetic and Electron Paramagnetic Resonance Spectroscopy > 5.3 The Electron Paramagnetic Resonance g-tensor
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&LINRES%EPR%PRINT%G_TENSOR%XC%XC_FUNCTIONAL

--- a/cp2k-made-simple/paper-snippets/055-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-dft-print-hyperfine-coupling-tensor.inp
+++ b/cp2k-made-simple/paper-snippets/055-5-nuclear-magnetic-and-electron-paramagnetic-resonance-s-dft-print-hyperfine-coupling-tensor.inp
@@ -1,0 +1,6 @@
+! CP2K Made Simple paper snippet 055
+! Section: The CP2K Program Package Made Simple > 5 Nuclear Magnetic and Electron Paramagnetic Resonance Spectroscopy > 5.4 Hyperfine Couplings
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&DFT%PRINT%HYPERFINE_COUPLING_TENSOR

--- a/cp2k-made-simple/paper-snippets/056-6-optical-spectroscopy-tddfpt.inp
+++ b/cp2k-made-simple/paper-snippets/056-6-optical-spectroscopy-tddfpt.inp
@@ -1,0 +1,12 @@
+! CP2K Made Simple paper snippet 056
+! Section: The CP2K Program Package Made Simple > 6 Optical Spectroscopy > 6.1 Linear-Response Time-Dependent Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&TDDFPT
+  KERNEL FULL
+  NSTATES 10
+  MAX_ITER 50
+  CONVERGENCE [eV] 1.0E-6
+  RKS_TRIPLETS F
+&END TDDFPT

--- a/cp2k-made-simple/paper-snippets/057-6-optical-spectroscopy-stda.inp
+++ b/cp2k-made-simple/paper-snippets/057-6-optical-spectroscopy-stda.inp
@@ -1,0 +1,10 @@
+! CP2K Made Simple paper snippet 057
+! Section: The CP2K Program Package Made Simple > 6 Optical Spectroscopy > 6.1 Linear-Response Time-Dependent Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+KERNEL sTDA
+&sTDA
+  FRACTION 0.2
+  DO_EWALD TRUE
+&END sTDA

--- a/cp2k-made-simple/paper-snippets/058-6-optical-spectroscopy-dft.inp
+++ b/cp2k-made-simple/paper-snippets/058-6-optical-spectroscopy-dft.inp
@@ -1,0 +1,10 @@
+! CP2K Made Simple paper snippet 058
+! Section: The CP2K Program Package Made Simple > 6 Optical Spectroscopy > 6.1 Linear-Response Time-Dependent Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&DFT
+  &EXCITED_STATES
+    STATE 1
+  &END EXCITED_STATES
+&END DFT

--- a/cp2k-made-simple/paper-snippets/059-6-optical-spectroscopy-print.inp
+++ b/cp2k-made-simple/paper-snippets/059-6-optical-spectroscopy-print.inp
@@ -1,0 +1,11 @@
+! CP2K Made Simple paper snippet 059
+! Section: The CP2K Program Package Made Simple > 6 Optical Spectroscopy > 6.1 Linear-Response Time-Dependent Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&PRINT
+  &SOC_PRINT
+    SOME
+    SPLITTING
+  &END SOC_PRINT
+&END PRINT

--- a/cp2k-made-simple/paper-snippets/060-6-optical-spectroscopy-gw.inp
+++ b/cp2k-made-simple/paper-snippets/060-6-optical-spectroscopy-gw.inp
@@ -1,0 +1,19 @@
+! CP2K Made Simple paper snippet 060
+! Section: The CP2K Program Package Made Simple > 6 Optical Spectroscopy > 6.2 Bethe-Salpeter Equation > 6.2.2 Optical absorption spectrum
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&GW
+  SELF_CONSISTENCY      evGW0
+  &BSE
+    TDA                 TDA+ABBA
+    SPIN_CONFIG         SINGLET
+    NUM_PRINT_EXC       15
+    ENERGY_CUTOFF_OCC   -1
+    ENERGY_CUTOFF_EMPTY -1
+    NUM_PRINT_EXC_DESCR -1
+    &BSE_SPECTRUM
+      ETA_LIST 0.01 0.02
+    &END BSE_SPECTRUM
+  &END BSE
+&END GW

--- a/cp2k-made-simple/paper-snippets/061-7-excited-state-dynamics-real-time-propagation.inp
+++ b/cp2k-made-simple/paper-snippets/061-7-excited-state-dynamics-real-time-propagation.inp
@@ -1,0 +1,40 @@
+! CP2K Made Simple paper snippet 061
+! Section: The CP2K Program Package Made Simple > 7 Excited State Dynamics > 7.2 Real-Time Bethe Salpeter Propagation
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&REAL_TIME_PROPAGATION
+  &RTBSE ! Start the RTBSE Method
+    FT_DAMPING [fs] 5.0 ! FT damping
+    FT_START_TIME 0.0 ! FT offset
+    &PADE_FT ! Pad interpolation
+      E_MIN [eV] 0.0
+      E_MAX [eV] 50.0
+      E_STEP [eV] 0.001
+      FIT_E_MIN [eV] 0.0
+      FIT_E_MAX [eV] 300.0
+    &END PADE_FT
+  &END RTBSE
+  EPS_ITER 1.0E-8 ! Check convergence
+  MAX_ITER 50
+  MAT_EXP BCH
+  EXP_ACCURACY 1.0E-14 ! < EPS_ITER
+  APPLY_DELTA_PULSE
+  DELTA_PULSE_DIRECTION 1 0 0
+  DELTA_PULSE_SCALE 0.0001
+  &PRINT
+    &MOMENTS ! Print moments time trace
+      FILENAME MOMENTS
+    &END MOMENTS
+    &MOMENTS_FT ! Fourier transform
+      FILENAME MOMENTS_FT
+    &END MOMENTS_FT
+    &FIELD ! Print applied field trace
+      FILENAME FIELD
+    &END FIELD
+    &POLARIZABILITY
+      FILENAME POLARIZABILITY
+      ELEMENT 1 1 ! Tensor element
+    &END POLARIZABILITY
+  &END PRINT
+&END REAL_TIME_PROPAGATION

--- a/cp2k-made-simple/paper-snippets/062-7-excited-state-dynamics-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/062-7-excited-state-dynamics-force-eval.inp
@@ -1,0 +1,20 @@
+! CP2K Made Simple paper snippet 062
+! Section: The CP2K Program Package Made Simple > 7 Excited State Dynamics > 7.3 Surface Hopping via NEWTON-X
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  &PRINT
+    &FORCES
+    &END FORCES
+  &END PRINT
+  ...
+&END FORCE_EVAL
+&TDDFPT
+  &PRINT
+    &NAMD_PRINT
+      PRINT_VIRTUALS T
+    &END NAMD_PRINT
+  &END PRINT
+  ...
+&END TDDFPT

--- a/cp2k-made-simple/paper-snippets/063-7-excited-state-dynamics-vibrational-analysis.inp
+++ b/cp2k-made-simple/paper-snippets/063-7-excited-state-dynamics-vibrational-analysis.inp
@@ -1,0 +1,11 @@
+! CP2K Made Simple paper snippet 063
+! Section: The CP2K Program Package Made Simple > 7 Excited State Dynamics > 7.3 Surface Hopping via NEWTON-X
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&VIBRATIONAL_ANALYSIS
+  &PRINT
+    &NAMD_PRINT
+    &END NAMD_PRINT
+  &END PRINT
+&END VIBRATIONAL ANALYSIS

--- a/cp2k-made-simple/paper-snippets/064-8-x-ray-spectroscopy-xas.inp
+++ b/cp2k-made-simple/paper-snippets/064-8-x-ray-spectroscopy-xas.inp
@@ -1,0 +1,30 @@
+! CP2K Made Simple paper snippet 064
+! Section: The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.1 Transition Potential Method
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&XAS
+  &SCF
+    ...
+  &END SCF
+  METHOD        TP_HH
+  DIPOLE_FORM   VELOCITY
+  STATE_TYPE    1s
+  STATE_SEARCH  10
+  ATOMS_LIST    1
+  ADDED_MOS     1000
+  &LOCALIZE
+  &END LOCALIZE
+  &PRINT
+    &PROGRAM_RUN_INFO
+  &END PRINT
+  &RESTART
+    FILENAME ./root
+  &END RESTART
+  &XAS_SPECTRUM
+    FILENAME ./root
+  &END XAS_SPECTRUM
+  &XES_SPECTRUM
+    FILENAME ./root
+  &END XES_SPECTRUM
+&END XAS

--- a/cp2k-made-simple/paper-snippets/065-8-x-ray-spectroscopy-donor-states.inp
+++ b/cp2k-made-simple/paper-snippets/065-8-x-ray-spectroscopy-donor-states.inp
@@ -1,0 +1,12 @@
+! CP2K Made Simple paper snippet 065
+! Section: The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.2 Linear-Response Time-Dependent Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&DONOR_STATES
+  DEFINE_EXCITED BY_KIND
+  KIND_LIST O
+  LOCALIZE
+  N_SEARCH 3
+  STATE_TYPES 1s
+&END DONOR_STATES

--- a/cp2k-made-simple/paper-snippets/066-8-x-ray-spectroscopy-kernel.inp
+++ b/cp2k-made-simple/paper-snippets/066-8-x-ray-spectroscopy-kernel.inp
@@ -1,0 +1,19 @@
+! CP2K Made Simple paper snippet 066
+! Section: The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.2 Linear-Response Time-Dependent Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&KERNEL
+  &XC_FUNCTIONAL
+    &GGA_X_PBE
+    &END GGA_C_PBE
+    &GGA_X_PBE
+      SCALE 0.75
+    &END GGA_X_PBE
+  &END XC_FUNCTIONAL
+  &EXACT_EXCHANGE
+    FRACTION 0.25
+    OPERATOR TRUNCATED
+    CUTOFF_RADIUS 6.0
+  &END EXACT_EXCHANGE
+&END KERNEL

--- a/cp2k-made-simple/paper-snippets/067-8-x-ray-spectroscopy-grid-o-100-250.inp
+++ b/cp2k-made-simple/paper-snippets/067-8-x-ray-spectroscopy-grid-o-100-250.inp
@@ -1,0 +1,6 @@
+! CP2K Made Simple paper snippet 067
+! Section: The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.2 Linear-Response Time-Dependent Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+GRID O 100 250

--- a/cp2k-made-simple/paper-snippets/068-8-x-ray-spectroscopy-spin-orbit-coupling.inp
+++ b/cp2k-made-simple/paper-snippets/068-8-x-ray-spectroscopy-spin-orbit-coupling.inp
@@ -1,0 +1,8 @@
+! CP2K Made Simple paper snippet 068
+! Section: The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.2 Linear-Response Time-Dependent Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+SPIN_ORBIT_COUPLING
+EXCITATIONS RCS_SINGLET
+EXCITATIONS RCS_TRIPLET

--- a/cp2k-made-simple/paper-snippets/069-8-x-ray-spectroscopy-real-time-propagation.inp
+++ b/cp2k-made-simple/paper-snippets/069-8-x-ray-spectroscopy-real-time-propagation.inp
@@ -1,0 +1,22 @@
+! CP2K Made Simple paper snippet 069
+! Section: The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.3 Real-Time Time-Dependent Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&REAL_TIME_PROPAGATION
+  INITIAL_WFN  SCF_WFN
+  PROPAGATOR ETRS
+  EXP_ACCURACY 1E-15
+  EPS_ITER 1E-9
+  MAX_ITER 100
+  MAT_EXP TAYLOR
+  APPLY_DELTA_PULSE .TRUE.
+  DELTA_PULSE_DIRECTION 0 0 1
+  DELTA_PULSE_SCALE 0.001
+&END REAL_TIME_PROPAGATION
+&PRINT
+  &MOMENTS
+    FILENAME =mom.dat
+    PERIODIC F
+  &END MOMENTS
+&END PRINT

--- a/cp2k-made-simple/paper-snippets/070-8-x-ray-spectroscopy-real-time-propagation.inp
+++ b/cp2k-made-simple/paper-snippets/070-8-x-ray-spectroscopy-real-time-propagation.inp
@@ -1,0 +1,32 @@
+! CP2K Made Simple paper snippet 070
+! Section: The CP2K Program Package Made Simple > 8 X-Ray Spectroscopy > 8.3 Real-Time Time-Dependent Density Functional Theory
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&REAL_TIME_PROPAGATION
+  INITIAL_WFN SCF_WFN
+  PROPAGATOR ETRS
+  EXP_ACCURACY 1E-15
+  EPS_ITER 1E-9
+  MAX_ITER 100
+  MAT_EXP TAYLOR
+  VELOCITY_GAUGE
+  &PRINT
+    &FIELD
+    &END FIELD
+    &E_CONSTITUENTS
+    &END E_CONSTITUENTS
+    &CURRENT_INT
+    &END CURRENT_INT
+  &END PRINT
+&END REAL_TIME_PROPAGATION
+&EFIELD
+  INTENSITY 3.5E10
+  POLARISATION  0  0  1
+  ENVELOP GAUSSIAN
+  &GAUSSIAN_ENV
+    T0 [fs]    0.006240
+    SIGMA [fs] 0.002340
+  &END GAUSSIAN_ENV
+  VEC_POT_INITIAL  0.00 0.00 ${VECZ}
+&END

--- a/cp2k-made-simple/paper-snippets/071-9-energy-decomposition-analysis-subsys.inp
+++ b/cp2k-made-simple/paper-snippets/071-9-energy-decomposition-analysis-subsys.inp
@@ -1,0 +1,14 @@
+! CP2K Made Simple paper snippet 071
+! Section: The CP2K Program Package Made Simple > 9 Energy Decomposition Analysis > 9.1 Implementation
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&SUBSYS
+  &TOPOLOGY
+    &GENERATE
+      BONDLENGTH_MAX 1.0
+      BONDPARM COVALENT
+      BONDPARM_FACTOR 0.3
+    &END GENERATE
+  &END TOPOLOGY
+&END SUBSYS

--- a/cp2k-made-simple/paper-snippets/072-9-energy-decomposition-analysis-subsys.inp
+++ b/cp2k-made-simple/paper-snippets/072-9-energy-decomposition-analysis-subsys.inp
@@ -1,0 +1,38 @@
+! CP2K Made Simple paper snippet 072
+! Section: The CP2K Program Package Made Simple > 9 Energy Decomposition Analysis > 9.1 Implementation
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+  &SUBSYS
+    &KIND H
+      ...
+      &BS
+        &ALPHA
+          NEL -1
+          L    0
+          N    1
+        &END
+        &BETA
+          NEL -1
+          L    0
+          N    1
+        &END
+      &END
+    &END KIND
+
+    &KIND O
+      ...
+      &BS
+        &ALPHA
+          NEL +2
+          L    1
+          N    2
+        &END
+        &BETA
+          NEL +2
+          L    1
+          N    2
+        &END
+      &END
+    &END KIND
+  &END SUBSYS

--- a/cp2k-made-simple/paper-snippets/073-9-energy-decomposition-analysis-qs.inp
+++ b/cp2k-made-simple/paper-snippets/073-9-energy-decomposition-analysis-qs.inp
@@ -1,0 +1,37 @@
+! CP2K Made Simple paper snippet 073
+! Section: The CP2K Program Package Made Simple > 9 Energy Decomposition Analysis > 9.1 Implementation
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&QS
+  ALMO_SCF T
+&END QS
+&ALMO_SCF
+  ALMO_ALGORITHM DIAG
+  ALMO_SCF_GUESS MOLECULAR
+  DELOCALIZE_METHOD FULL_X_THEN_SCF
+  EPS_FILTER 1.0E-10
+  &ALMO_OPTIMIZER_DIIS
+    EPS_ERROR 1.0E-5
+    MAX_ITER 10
+    N_DIIS 5
+  &END ALMO_OPTIMIZER_DIIS
+  &ANALYSIS T
+    &PRINT
+      &ALMO_CTA
+        FILENAME charge_terms
+      &END ALMO_CTA
+      &ALMO_EDA_CT
+        FILENAME energy_terms
+      &END ALMO_EDA_CT
+    &END PRINT
+  &END ANALYSIS
+  &XALMO_OPTIMIZER_PCG
+    CONJUGATOR DAI_YUAN
+    EPS_ERROR 1.0E-5
+    LIN_SEARCH_EPS_ERROR 0.1
+    LIN_SEARCH_STEP_SIZE_GUESS 0.5
+    MAX_ITER 100
+    MAX_ITER_OUTER_LOOP 0
+  &END XALMO_OPTIMIZER_PCG
+&END ALMO_SCF

--- a/cp2k-made-simple/paper-snippets/074-10-finite-temperature-effects-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/074-10-finite-temperature-effects-force-eval.inp
@@ -1,0 +1,15 @@
+! CP2K Made Simple paper snippet 074
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.1 Neural Network and Machine Learning Interaction Potentials
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  METHOD NNP
+  &NNP
+    NNP_INPUT_FILE_NAME input.nn
+    SCALE_FILE_NAME scaling.data
+    &MODEL
+      WEIGHTS weigths
+    &END MODEL
+  &END NNP
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/075-10-finite-temperature-effects-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/075-10-finite-temperature-effects-force-eval.inp
@@ -1,0 +1,21 @@
+! CP2K Made Simple paper snippet 075
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.1 Neural Network and Machine Learning Interaction Potentials
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  METHOD NNP
+  &NNP
+    NNP_INPUT_FILE_NAME input.nn
+    SCALE_FILE_NAME scaling.data
+    &MODEL
+      WEIGHTS nnp-1/weigths
+    &END MODEL
+    &MODEL
+      WEIGHTS nnp-2/weigths
+    &END MODEL
+    &MODEL
+      WEIGHTS nnp-3/weigths
+    &END MODEL
+  &END NNP
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/076-10-finite-temperature-effects-print.inp
+++ b/cp2k-made-simple/paper-snippets/076-10-finite-temperature-effects-print.inp
@@ -1,0 +1,12 @@
+! CP2K Made Simple paper snippet 076
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.1 Neural Network and Machine Learning Interaction Potentials
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&PRINT
+  &ENERGIES
+    &EACH
+     MD 1
+    &END EACH
+  &END ENERGIES
+&END PRINT

--- a/cp2k-made-simple/paper-snippets/077-10-finite-temperature-effects-bias.inp
+++ b/cp2k-made-simple/paper-snippets/077-10-finite-temperature-effects-bias.inp
@@ -1,0 +1,9 @@
+! CP2K Made Simple paper snippet 077
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.1 Neural Network and Machine Learning Interaction Potentials
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&BIAS
+  SIGMA_0 [hartree] 0.0001
+  K_B 5000
+&END BIAS

--- a/cp2k-made-simple/paper-snippets/078-10-finite-temperature-effects-pint.inp
+++ b/cp2k-made-simple/paper-snippets/078-10-finite-temperature-effects-pint.inp
@@ -1,0 +1,14 @@
+! CP2K Made Simple paper snippet 078
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.2 Nuclear Quantum Effects
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&PINT
+  P 32
+  NUM_STEPS 1000
+  TEMP       250
+  DT        0.25
+  TRANSFORMATION NORMAL
+  HARM_INT EXACT
+  PROPAGATOR PIMD
+&END PINT

--- a/cp2k-made-simple/paper-snippets/079-10-finite-temperature-effects-nose.inp
+++ b/cp2k-made-simple/paper-snippets/079-10-finite-temperature-effects-nose.inp
@@ -1,0 +1,8 @@
+! CP2K Made Simple paper snippet 079
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.2 Nuclear Quantum Effects
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&NOSE
+  NNOS 5
+&END NOSE

--- a/cp2k-made-simple/paper-snippets/080-10-finite-temperature-effects-pile.inp
+++ b/cp2k-made-simple/paper-snippets/080-10-finite-temperature-effects-pile.inp
@@ -1,0 +1,9 @@
+! CP2K Made Simple paper snippet 080
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.2 Nuclear Quantum Effects
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&PILE
+  LAMBDA 0.5
+  TAU 1000.0
+&END PILE

--- a/cp2k-made-simple/paper-snippets/081-10-finite-temperature-effects-qtb.inp
+++ b/cp2k-made-simple/paper-snippets/081-10-finite-temperature-effects-qtb.inp
@@ -1,0 +1,11 @@
+! CP2K Made Simple paper snippet 081
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.3 Quantum Convergence
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&QTB
+  LAMBDA 0.2
+  TAU 50.0
+  TAUCUT 0.9
+  LAMBCUT 1.5
+&END QTB

--- a/cp2k-made-simple/paper-snippets/082-10-finite-temperature-effects-pint.inp
+++ b/cp2k-made-simple/paper-snippets/082-10-finite-temperature-effects-pint.inp
@@ -1,0 +1,19 @@
+! CP2K Made Simple paper snippet 082
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.4 Approximate Quantum Dynamics
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&PINT
+  P 32
+  NUM_STEPS 1000
+  TEMP       250
+  DT        0.25
+  HARM_INT  EXACT
+  NRESPA 1
+  TRANSFORMATION NORMAL
+  PROPAGATOR RPMD
+  &PILE
+    TAU  -1000
+    LAMBDA 0.5
+  &END PILE
+&END PINT

--- a/cp2k-made-simple/paper-snippets/083-10-finite-temperature-effects-helium.inp
+++ b/cp2k-made-simple/paper-snippets/083-10-finite-temperature-effects-helium.inp
@@ -1,0 +1,12 @@
+! CP2K Made Simple paper snippet 083
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.5 Bosonic Quantum Solvation at Ultra-low Temperatures
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&HELIUM
+   ....
+   CELL_SHAPE OCTAHEDRON
+   PERIODIC T
+   SAMPLING_METHOD WORM
+   ....
+&END HELIUM

--- a/cp2k-made-simple/paper-snippets/084-10-finite-temperature-effects-motion.inp
+++ b/cp2k-made-simple/paper-snippets/084-10-finite-temperature-effects-motion.inp
@@ -1,0 +1,23 @@
+! CP2K Made Simple paper snippet 084
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.5 Bosonic Quantum Solvation at Ultra-low Temperatures
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&MOTION
+  &PINT
+    NUM_STEPS 100
+    &HELIUM
+      HELIUM_ONLY
+      NATOMS 32
+      NBEADS 80
+      DENSITY 0.0218312
+      CELL_SHAPE OCTAHEDRON
+      PERIODIC T
+      POTENTIAL_FILE_NAME \
+          helium_aziz95_80k.potx
+      PRESAMPLE T
+      SAMPLING_METHOD WORM
+      N_OUTER 10000
+    &END HELIUM
+  &END PINT
+&END MOTION

--- a/cp2k-made-simple/paper-snippets/085-10-finite-temperature-effects-motion.inp
+++ b/cp2k-made-simple/paper-snippets/085-10-finite-temperature-effects-motion.inp
@@ -1,0 +1,76 @@
+! CP2K Made Simple paper snippet 085
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.5 Bosonic Quantum Solvation at Ultra-low Temperatures
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&MOTION
+  &PINT
+    DT 0.1
+    NUM_STEPS 1000000
+    P 160
+    PROPAGATOR RPMD
+    TEMP 1.0
+    &HELIUM T
+      CELL_SHAPE OCTAHEDRON
+      CELL_SIZE 19.1157
+      DROPLET_RADIUS 15.0
+      GET_FORCES LAST
+      NATOMS 8
+      NBEADS 80
+      N_OUTER 1000
+      PERIODIC F
+      POTENTIAL_FILE_NAME ./helium.potx
+      PRESAMPLE T
+      SAMPLING_METHOD WORM
+      SOLUTE_INTERACTION NNP
+      &NNP
+        NNP_INPUT_FILE_NAME inter-input.nn
+        SCALE_FILE_NAME inter-scaling.data
+        &MODEL
+          WEIGHTS inter-weights
+        &END MODEL
+        &SR_CUTOFF
+          ELEMENT "H"
+          RADIUS  1.25
+        &END SR_CUTOFF
+        &SR_CUTOFF
+          ELEMENT "He"
+          RADIUS  0.00
+        &END SR_CUTOFF
+        &SR_CUTOFF
+          ELEMENT "O"
+          RADIUS  2.05
+        &END SR_CUTOFF
+      &END NNP
+      &WORM
+        ALLOW_OPEN T
+        CENTROID_DRMAX  0.25
+        MAX_OPEN_CYCLES 100
+        OPEN_CLOSE_SCALE  50.0
+        STAGING_L 6
+      &END WORM
+    &END HELIUM
+    &PILE
+       LAMBDA 0.5
+       TAU 200
+    &END PILE
+  &END PINT
+&END MOTION
+&FORCE_EVAL
+  METHOD NNP
+  &NNP
+    NNP_INPUT_FILE_NAME solute-input.nn
+    SCALE_FILE_NAME solute-scaling.data
+    &MODEL
+      WEIGHTS solute-weights
+    &END MODEL
+  &END NNP
+  &SUBSYS
+    &COORD
+      O  0.00  0.00  0.00
+      H  1.05  0.00  0.00
+      H -0.49  0.77  0.00
+      H -0.55 -0.51 -0.48
+    &END COORD
+  &END SUBSYS
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/086-10-finite-temperature-effects-global.inp
+++ b/cp2k-made-simple/paper-snippets/086-10-finite-temperature-effects-global.inp
@@ -1,0 +1,13 @@
+! CP2K Made Simple paper snippet 086
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.1 Static-Harmonic Approach
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&GLOBAL
+  RUN_TYPE VIBRATIONAL_ANALYSIS
+&END GLOBAL
+&VIBRATIONAL_ANALYSIS
+  DX 0.01
+  FULLY_PERIODIC TRUE
+  INTENSITIES TRUE
+&END VIBRATIONAL_ANALYSIS

--- a/cp2k-made-simple/paper-snippets/087-10-finite-temperature-effects-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/087-10-finite-temperature-effects-force-eval.inp
@@ -1,0 +1,13 @@
+! CP2K Made Simple paper snippet 087
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.3 Computing Electromagnetic Moments
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  &DFT
+    &PRINT
+      &MOMENTS
+      &END MOMENTS
+    &END PRINT
+  &END DFT
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/088-10-finite-temperature-effects-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/088-10-finite-temperature-effects-force-eval.inp
@@ -1,0 +1,11 @@
+! CP2K Made Simple paper snippet 088
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.5 Orbital Localization
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  &DFT
+    &LOCALIZE
+    &END LOCALIZE
+  &END DFT
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/089-10-finite-temperature-effects-dft.inp
+++ b/cp2k-made-simple/paper-snippets/089-10-finite-temperature-effects-dft.inp
@@ -1,0 +1,11 @@
+! CP2K Made Simple paper snippet 089
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.6 Voronoi Integration
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&DFT
+  &PRINT
+    &VORONOI
+    &END VORONOI
+  &END PRINT
+&END DFT

--- a/cp2k-made-simple/paper-snippets/090-10-finite-temperature-effects-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/090-10-finite-temperature-effects-force-eval.inp
@@ -1,0 +1,13 @@
+! CP2K Made Simple paper snippet 090
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.7 Polarizabilities
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  &DFT
+    &PERIODIC_EFIELD
+      INTENSITY 5.0E-3
+      POLARISATION 1.0 0.0 0.0
+    &END PERIODIC_EFIELD
+  &END DFT
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/091-10-finite-temperature-effects-force-eval.inp
+++ b/cp2k-made-simple/paper-snippets/091-10-finite-temperature-effects-force-eval.inp
@@ -1,0 +1,13 @@
+! CP2K Made Simple paper snippet 091
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.7 Polarizabilities
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&FORCE_EVAL
+  &PROPERTIES
+    &LINRES
+      &POLAR
+      &END POLAR
+    &END LINRES
+  &END PROPERTIES
+&END FORCE_EVAL

--- a/cp2k-made-simple/paper-snippets/092-10-finite-temperature-effects-dft.inp
+++ b/cp2k-made-simple/paper-snippets/092-10-finite-temperature-effects-dft.inp
@@ -1,0 +1,12 @@
+! CP2K Made Simple paper snippet 092
+! Section: The CP2K Program Package Made Simple > 10 Finite Temperature Effects > 10.6 Vibrational Spectroscopy > 10.6.9 Supported Types of Spectra > Storing Compressed Density Cubes:
+! Source: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+! Status: illustrative fragment; see ../README.md before running.
+
+&DFT
+  &PRINT
+    &E_DENSITY_BQB
+      FILENAME result.bqb
+    &END E_DENSITY_BQB
+  &END PRINT
+&END DFT

--- a/cp2k-made-simple/runnable/README.md
+++ b/cp2k-made-simple/runnable/README.md
@@ -1,0 +1,29 @@
+# Runnable CP2K Made Simple Examples
+
+This directory contains complete CP2K inputs derived from selected snippets of the paper
+["The CP2K Program Package Made Simple"](https://doi.org/10.1021/acs.jpcb.5c05851).
+
+The raw extracted snippets remain in `../paper-snippets/`. The files here are curated examples:
+they add the missing cell, coordinates, basis-set/potential choices, and method context needed for
+small standalone calculations.
+
+## Examples
+
+| input | topic | based on snippets | local test result |
+| --- | --- | --- | --- |
+| `dft/h2o-gpw-pbe.inp` | GPW/PBE single point | 001, 002 | energy -17.212337144585153 Ha |
+| `dft/h2o-gpw-ot.inp` | GPW/PBE with OT | 001, 005, 006 | energy -17.212337144506982 Ha |
+| `dft/h2o-gpw-smearing.inp` | GPW/PBE with smearing | 001, 005 | energy -17.212334309139813 Ha |
+| `gapw/h2o-gapw-all-electron.inp` | all-electron GAPW/PBE | 003, 004 | energy -76.238068224190314 Ha |
+| `hfx-admm/h2o-pbe0-admm.inp` | hybrid DFT with ADMM | 010, 011, 012, 013 | energy -17.151344159601688 Ha |
+| `properties/h2o-tddfpt.inp` | linear-response TDDFPT | 056 | first excitation 8.43471 eV |
+
+Run from this directory, for example:
+
+```bash
+CP2K_DATA_DIR=/path/to/cp2k/data cp2k.psmp -i dft/h2o-gpw-pbe.inp -o h2o-gpw-pbe.out
+```
+
+When CP2K has been installed with a configured data directory, `CP2K_DATA_DIR` is not needed.
+
+The results above were checked with a local `cp2k.psmp` build using `OMP_NUM_THREADS=1`.

--- a/cp2k-made-simple/runnable/dft/h2o-gpw-ot.inp
+++ b/cp2k-made-simple/runnable/dft/h2o-gpw-ot.inp
@@ -1,0 +1,66 @@
+! Quickstep/GPW water single-point calculation using orbital transformation.
+! Derived from CP2K Made Simple snippets 001, 005, and 006.
+! Reference: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+
+&GLOBAL
+  PROJECT h2o-gpw-ot
+  RUN_TYPE ENERGY
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_MOLOPT
+    POTENTIAL_FILE_NAME GTH_POTENTIALS
+    &QS
+      EPS_DEFAULT 1.0E-12
+      METHOD GPW
+    &END QS
+    &MGRID
+      CUTOFF 400
+      REL_CUTOFF 50
+      NGRIDS 5
+      PROGRESSION_FACTOR 3.0
+    &END MGRID
+    &POISSON
+      PERIODIC NONE
+      PSOLVER MT
+    &END POISSON
+    &SCF
+      EPS_SCF 1.0E-6
+      MAX_SCF 50
+      SCF_GUESS ATOMIC
+      &OT
+        MINIMIZER DIIS
+        PRECONDITIONER FULL_SINGLE_INVERSE
+      &END OT
+      &OUTER_SCF
+        EPS_SCF 1.0E-7
+        MAX_SCF 10
+      &END OUTER_SCF
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PBE
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 10.0 10.0 10.0
+      PERIODIC NONE
+    &END CELL
+    &COORD
+      O  5.0000  5.0000  5.0000
+      H  5.7586  5.0000  5.5043
+      H  4.2414  5.0000  5.5043
+    &END COORD
+    &KIND O
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-PBE-q6
+    &END KIND
+    &KIND H
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-PBE-q1
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL

--- a/cp2k-made-simple/runnable/dft/h2o-gpw-pbe.inp
+++ b/cp2k-made-simple/runnable/dft/h2o-gpw-pbe.inp
@@ -1,0 +1,51 @@
+! Minimal Quickstep/GPW water single-point calculation using PBE.
+! Derived from CP2K Made Simple snippets 001 and 002.
+! Reference: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+
+&GLOBAL
+  PROJECT h2o
+  RUN_TYPE ENERGY
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_MOLOPT
+    POTENTIAL_FILE_NAME GTH_POTENTIALS
+    &MGRID
+      CUTOFF 400
+      REL_CUTOFF 50
+    &END MGRID
+    &POISSON
+      PERIODIC NONE
+      PSOLVER MT
+    &END POISSON
+    &SCF
+      EPS_SCF 1.0E-6
+      MAX_SCF 50
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PBE
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 10.0 10.0 10.0
+      PERIODIC NONE
+    &END CELL
+    &COORD
+      O  5.0000  5.0000  5.0000
+      H  5.7586  5.0000  5.5043
+      H  4.2414  5.0000  5.5043
+    &END COORD
+    &KIND O
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-PBE-q6
+    &END KIND
+    &KIND H
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-PBE-q1
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL

--- a/cp2k-made-simple/runnable/dft/h2o-gpw-smearing.inp
+++ b/cp2k-made-simple/runnable/dft/h2o-gpw-smearing.inp
@@ -1,0 +1,72 @@
+! Quickstep/GPW water single-point calculation using diagonalization and smearing.
+! Derived from CP2K Made Simple snippets 001 and 005.
+! Reference: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+
+&GLOBAL
+  PROJECT h2o-gpw-smearing
+  RUN_TYPE ENERGY
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_MOLOPT
+    POTENTIAL_FILE_NAME GTH_POTENTIALS
+    &QS
+      EPS_DEFAULT 1.0E-12
+      METHOD GPW
+    &END QS
+    &MGRID
+      CUTOFF 400
+      REL_CUTOFF 50
+      NGRIDS 5
+      PROGRESSION_FACTOR 3.0
+    &END MGRID
+    &POISSON
+      PERIODIC NONE
+      PSOLVER MT
+    &END POISSON
+    &SCF
+      ADDED_MOS 10
+      EPS_SCF 1.0E-6
+      MAX_SCF 80
+      SCF_GUESS ATOMIC
+      &DIAGONALIZATION
+        ALGORITHM STANDARD
+      &END DIAGONALIZATION
+      &MIXING
+        ALPHA 0.2
+        BETA 0.8
+        METHOD BROYDEN_MIXING
+        NBROYDEN 10
+      &END MIXING
+      &SMEAR
+        ELECTRONIC_TEMPERATURE [K] 300
+        METHOD FERMI_DIRAC
+      &END SMEAR
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PBE
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 10.0 10.0 10.0
+      PERIODIC NONE
+    &END CELL
+    &COORD
+      O  5.0000  5.0000  5.0000
+      H  5.7586  5.0000  5.5043
+      H  4.2414  5.0000  5.5043
+    &END COORD
+    &KIND O
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-PBE-q6
+    &END KIND
+    &KIND H
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-PBE-q1
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL

--- a/cp2k-made-simple/runnable/gapw/h2o-gapw-all-electron.inp
+++ b/cp2k-made-simple/runnable/gapw/h2o-gapw-all-electron.inp
@@ -1,0 +1,60 @@
+! Minimal all-electron Quickstep/GAPW water single-point calculation.
+! Derived from CP2K Made Simple snippets 003 and 004.
+! Reference: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+
+&GLOBAL
+  PROJECT gapw_h2o
+  RUN_TYPE ENERGY
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_MOLOPT_UZH
+    &MGRID
+      CUTOFF 800
+      REL_CUTOFF 80
+    &END MGRID
+    &POISSON
+      PERIODIC NONE
+      PSOLVER MT
+    &END POISSON
+    &QS
+      EPSFIT 1.0E-6
+      EPSRHO0 1.0E-8
+      EPSSVD 1.0E-10
+      METHOD GAPW
+    &END QS
+    &SCF
+      EPS_SCF 1.0E-6
+      MAX_SCF 50
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PBE
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 10.0 10.0 10.0
+      PERIODIC NONE
+    &END CELL
+    &COORD
+      O  5.0000  5.0000  5.0000
+      H  5.7586  5.0000  5.5043
+      H  4.2414  5.0000  5.5043
+    &END COORD
+    &KIND O
+      BASIS_SET SVP-MOLOPT-GGA-ae
+      LEBEDEV_GRID 110
+      POTENTIAL ALL
+      RADIAL_GRID 80
+    &END KIND
+    &KIND H
+      BASIS_SET SVP-MOLOPT-GGA-ae
+      LEBEDEV_GRID 110
+      POTENTIAL ALL
+      RADIAL_GRID 80
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL

--- a/cp2k-made-simple/runnable/hfx-admm/h2o-pbe0-admm.inp
+++ b/cp2k-made-simple/runnable/hfx-admm/h2o-pbe0-admm.inp
@@ -1,0 +1,71 @@
+! Quickstep/GPW water single-point calculation using PBE0 and ADMM.
+! Derived from CP2K Made Simple snippets 010, 011, 012, and 013.
+! Reference: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+
+&GLOBAL
+  PROJECT h2o-pbe0-admm
+  RUN_TYPE ENERGY
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_ccGRB_UZH
+    BASIS_SET_FILE_NAME BASIS_ADMM_UZH
+    POTENTIAL_FILE_NAME POTENTIAL_UZH
+    &AUXILIARY_DENSITY_MATRIX_METHOD
+      ADMM_TYPE ADMMS
+      EXCH_CORRECTION_FUNC PBEX
+    &END AUXILIARY_DENSITY_MATRIX_METHOD
+    &MGRID
+      CUTOFF 400
+      REL_CUTOFF 50
+    &END MGRID
+    &POISSON
+      PERIODIC NONE
+      PSOLVER MT
+    &END POISSON
+    &SCF
+      EPS_SCF 1.0E-6
+      MAX_SCF 80
+      SCF_GUESS ATOMIC
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL
+        &GGA_C_PBE
+        &END GGA_C_PBE
+        &GGA_X_PBE
+          SCALE 0.75
+        &END GGA_X_PBE
+      &END XC_FUNCTIONAL
+      &HF
+        FRACTION 0.25
+        &INTERACTION_POTENTIAL
+          CUTOFF_RADIUS 4.0
+          POTENTIAL_TYPE TRUNCATED
+        &END INTERACTION_POTENTIAL
+      &END HF
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 10.0 10.0 10.0
+      PERIODIC NONE
+    &END CELL
+    &COORD
+      O  5.0000  5.0000  5.0000
+      H  5.7586  5.0000  5.5043
+      H  4.2414  5.0000  5.5043
+    &END COORD
+    &KIND O
+      BASIS_SET ccGRB-D-q6
+      BASIS_SET AUX_FIT admm-dz-q6
+      POTENTIAL GTH-HYB-q6
+    &END KIND
+    &KIND H
+      BASIS_SET ccGRB-D-q1
+      BASIS_SET AUX_FIT admm-dz-q1
+      POTENTIAL GTH-HYB-q1
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL

--- a/cp2k-made-simple/runnable/manifest.tsv
+++ b/cp2k-made-simple/runnable/manifest.tsv
@@ -1,0 +1,7 @@
+file	topic	snippets	test_status	result
+dft/h2o-gpw-pbe.inp	GPW/PBE single point	001,002	passed	energy -17.212337144585153 Ha
+dft/h2o-gpw-ot.inp	GPW/PBE with OT	001,005,006	passed	energy -17.212337144506982 Ha
+dft/h2o-gpw-smearing.inp	GPW/PBE with diagonalization and smearing	001,005	passed	energy -17.212334309139813 Ha
+gapw/h2o-gapw-all-electron.inp	all-electron GAPW/PBE	003,004	passed	energy -76.238068224190314 Ha
+hfx-admm/h2o-pbe0-admm.inp	hybrid DFT with ADMM	010,011,012,013	passed	energy -17.151344159601688 Ha
+properties/h2o-tddfpt.inp	linear-response TDDFPT	056	passed	first excitation 8.43471 eV

--- a/cp2k-made-simple/runnable/properties/h2o-tddfpt.inp
+++ b/cp2k-made-simple/runnable/properties/h2o-tddfpt.inp
@@ -1,0 +1,72 @@
+! Quickstep/GPW water linear-response TDDFPT calculation.
+! Derived from CP2K Made Simple snippet 056.
+! Reference: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+
+&GLOBAL
+  PROJECT h2o-tddfpt
+  RUN_TYPE ENERGY
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_MOLOPT
+    POTENTIAL_FILE_NAME GTH_POTENTIALS
+    &QS
+      METHOD GPW
+    &END QS
+    &MGRID
+      CUTOFF 400
+      REL_CUTOFF 50
+    &END MGRID
+    &POISSON
+      PERIODIC NONE
+      PSOLVER MT
+    &END POISSON
+    &SCF
+      EPS_SCF 1.0E-7
+      MAX_SCF 50
+      SCF_GUESS ATOMIC
+      &OT
+        MINIMIZER DIIS
+        PRECONDITIONER FULL_SINGLE_INVERSE
+      &END OT
+      &OUTER_SCF
+        EPS_SCF 1.0E-7
+        MAX_SCF 10
+      &END OUTER_SCF
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PBE
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &PROPERTIES
+    &TDDFPT
+      CONVERGENCE [eV] 1.0E-5
+      KERNEL FULL
+      MAX_ITER 50
+      NSTATES 3
+      RKS_TRIPLETS F
+    &END TDDFPT
+  &END PROPERTIES
+  &SUBSYS
+    &CELL
+      ABC 10.0 10.0 10.0
+      PERIODIC NONE
+    &END CELL
+    &COORD
+      O  5.0000  5.0000  5.0000
+      H  5.7586  5.0000  5.5043
+      H  4.2414  5.0000  5.5043
+    &END COORD
+    &KIND O
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-PBE-q6
+    &END KIND
+    &KIND H
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-PBE-q1
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL


### PR DESCRIPTION
This PR adds example input material associated with the CP2K Made Simple paper.

What is included:
- `cp2k-made-simple/paper-snippets/`: extracted input fragments from the paper, kept as snippets because many are intentionally not standalone calculations.
- `cp2k-made-simple/manifest.tsv`: index of the extracted snippets.
- `cp2k-made-simple/runnable/`: small complete CP2K inputs derived from selected snippets.
- `cp2k-made-simple/runnable/manifest.tsv` and README with local reference results.

Local checks:
- `git diff --check origin/master...HEAD`
- Verified both manifests point to existing files.
- Ran all six runnable examples locally with `cp2k.psmp` and `OMP_NUM_THREADS=1`; all finished successfully.
  - GPW/PBE: `-17.212337144585153 Ha`
  - GPW/PBE with OT: `-17.212337144506982 Ha`
  - GPW/PBE with smearing: `-17.212334309139813 Ha`
  - GAPW/PBE all-electron: `-76.238068224190314 Ha`
  - PBE0/ADMM: `-17.151344159601688 Ha`
  - TDDFPT: first excitation `8.43471 eV`
