### PR TITLE
Expand CP2K Made Simple runnable examples and validation

### DIFF
--- a/cp2k-made-simple/README.md
+++ b/cp2k-made-simple/README.md
@@ -21,12 +21,16 @@ The derived complete examples are listed in `runnable/manifest.tsv`.
 From this directory, run for example:
 
 ```bash
+export OMP_NUM_THREADS=1
 cp2k.psmp -i runnable/02-total-energy-and-force-methods/h2o-gpw-pbe.inp -o h2o-gpw-pbe.out
 cp2k.psmp -i runnable/09-energy-decomposition-analysis/h2o-almo-eda.inp -o h2o-almo-eda.out
 ```
 
 If CP2K was built without a configured data directory, set `CP2K_DATA_DIR` to the CP2K `data`
-directory before running.
+directory before running. For quick local checks, prefer a single OpenMP thread and a separate
+work directory or output file for each calculation. The runnable examples are intentionally small;
+larger GW, BSE, SIRIUS, real-time XAS, and LIBVORI-dependent workflows are tracked separately in
+`optional-workflows/`.
 
 The complete examples in `runnable/` are curated derived inputs. Each file header lists the
 paper snippets it is based on; the raw extracted snippets remain unchanged in `paper-snippets/`.

--- a/cp2k-made-simple/README.md
+++ b/cp2k-made-simple/README.md
@@ -3,7 +3,7 @@
 This directory collects CP2K input material associated with the paper
 ["The CP2K Program Package Made Simple"](https://doi.org/10.1021/acs.jpcb.5c05851).
 
-The directory has two parts:
+The directory has four parts:
 
 - `runnable/` contains small, complete input files derived from selected paper snippets. They
   can be run directly with a CP2K binary and a standard CP2K data directory. The inputs are
@@ -11,6 +11,9 @@ The directory has two parts:
 - `paper-snippets/` contains 91 CP2K input fragments extracted from the paper. Many of these
   fragments intentionally show only the method-specific section and contain placeholders such as
   `...`, so they are not standalone calculations.
+- `guided-workflows/` groups runnable inputs into short learning paths.
+- `optional-workflows/` records larger, dependency-sensitive, or multi-stage workflows that are
+  better documented separately from the compact smoke-test inputs.
 
 The full list of extracted snippets is in `manifest.tsv`. The snippet numbering follows the order
 of code blocks in the paper HTML source used for extraction.
@@ -34,6 +37,12 @@ larger GW, BSE, SIRIUS, real-time XAS, and LIBVORI-dependent workflows are track
 
 The complete examples in `runnable/` are curated derived inputs. Each file header lists the
 paper snippets it is based on; the raw extracted snippets remain unchanged in `paper-snippets/`.
+
+For a quick local smoke test of representative inputs:
+
+```bash
+python3 runnable/run_smoke_tests.py --cp2k /path/to/cp2k.psmp --data-dir /path/to/cp2k/data --quick
+```
 
 See `runnable/README.md` for the full runnable-example table and local test results.
 The `guided-workflows/` directory groups runnable examples into short learning paths, while

--- a/cp2k-made-simple/README.md
+++ b/cp2k-made-simple/README.md
@@ -32,3 +32,5 @@ The complete examples in `runnable/` are curated derived inputs. Each file heade
 paper snippets it is based on; the raw extracted snippets remain unchanged in `paper-snippets/`.
 
 See `runnable/README.md` for the full runnable-example table and local test results.
+The `guided-workflows/` directory groups runnable examples into short learning paths, while
+`optional-workflows/` records larger or dependency-sensitive candidates for future examples.

--- a/cp2k-made-simple/README.md
+++ b/cp2k-made-simple/README.md
@@ -45,5 +45,6 @@ python3 runnable/run_smoke_tests.py --cp2k /path/to/cp2k.psmp --data-dir /path/t
 ```
 
 See `runnable/README.md` for the full runnable-example table and local test results.
+That table is generated from `runnable/manifest.tsv` with `runnable/generate_readme.py`.
 The `guided-workflows/` directory groups runnable examples into short learning paths, while
 `optional-workflows/` records larger or dependency-sensitive candidates for future examples.

--- a/cp2k-made-simple/guided-workflows/README.md
+++ b/cp2k-made-simple/guided-workflows/README.md
@@ -32,10 +32,20 @@ and ALMO energy decomposition.
 2. `../runnable/06-optical-spectroscopy/h2o-stda-tddfpt.inp`
 3. `../runnable/08-x-ray-spectroscopy/co-xas-transition-potential.inp`
 4. `../runnable/08-x-ray-spectroscopy/h2o-xastdp-gw2x.inp`
-5. `../runnable/10-finite-temperature-effects/h2o-linear-response-polarizability.inp`
+5. `../runnable/08-x-ray-spectroscopy/h2o-real-time-gaussian-field.inp`
+6. `../runnable/10-finite-temperature-effects/h2o-linear-response-polarizability.inp`
 
 This path walks through optical TDDFPT, sTDA, transition-potential XAS, XAS_TDP with GW2X, and a
-small linear-response polarizability calculation.
+short real-time Gaussian-field propagation before a small linear-response polarizability
+calculation.
+
+## Magnetic Response
+
+1. `../runnable/05-magnetic-resonance/h2o-nmr-linear-response.inp`
+2. `../runnable/05-magnetic-resonance/no2-epr-g-tensor.inp`
+3. `../runnable/05-magnetic-resonance/h2o-hyperfine-coupling.inp`
+
+This path covers NMR shielding, the EPR g-tensor, and EPR hyperfine coupling tensors.
 
 ## Finite-Temperature Methods
 
@@ -44,6 +54,8 @@ small linear-response polarizability calculation.
 3. `../runnable/10-finite-temperature-effects/h2o-pint-nve.inp`
 4. `../runnable/10-finite-temperature-effects/h2o-pint-pile.inp`
 5. `../runnable/10-finite-temperature-effects/h2o-vibrational-analysis.inp`
+6. `../runnable/10-finite-temperature-effects/h2o-periodic-efield.inp`
+7. `../runnable/10-finite-temperature-effects/h2o-orbital-localization.inp`
 
 This path covers committee neural-network potentials, a biased NNP trajectory, path-integral MD,
-and a static vibrational analysis.
+a static vibrational analysis, a periodic electric field, and orbital localization.

--- a/cp2k-made-simple/guided-workflows/README.md
+++ b/cp2k-made-simple/guided-workflows/README.md
@@ -1,0 +1,49 @@
+# CP2K Made Simple Guided Workflows
+
+The runnable inputs are intentionally small, but they can be combined into short learning paths.
+Each path below starts from an input that should run quickly, then moves toward a more specialized
+calculation.
+
+## Quickstep Ground State
+
+1. `../runnable/02-total-energy-and-force-methods/h2o-gpw-pbe.inp`
+2. `../runnable/02-total-energy-and-force-methods/h2o-gpw-ot.inp`
+3. `../runnable/02-total-energy-and-force-methods/h2o-gapw-all-electron.inp`
+4. `../runnable/02-total-energy-and-force-methods/h2o-pbe0-admm.inp`
+5. `../runnable/02-total-energy-and-force-methods/h2o-ri-mp2.inp`
+
+This path compares the basic GPW setup with OT minimization, all-electron GAPW, hybrid DFT with
+ADMM, and a compact RI-MP2 calculation.
+
+## Embedding and Fragment Workflows
+
+1. `../runnable/04-embedding-methods/h2o-sccs-solvation.inp`
+2. `../runnable/04-embedding-methods/h2o-qmmm-gaussian.inp`
+3. `../runnable/04-embedding-methods/ch3oh-resp-charges.inp`
+4. `../runnable/04-embedding-methods/h2o-h2-dfet.inp`
+5. `../runnable/09-energy-decomposition-analysis/h2o-almo-eda.inp`
+
+This path collects implicit solvation, QMMM electrostatic embedding, RESP charge fitting, DFET,
+and ALMO energy decomposition.
+
+## Spectroscopy and Response
+
+1. `../runnable/06-optical-spectroscopy/h2o-tddfpt.inp`
+2. `../runnable/06-optical-spectroscopy/h2o-stda-tddfpt.inp`
+3. `../runnable/08-x-ray-spectroscopy/co-xas-transition-potential.inp`
+4. `../runnable/08-x-ray-spectroscopy/h2o-xastdp-gw2x.inp`
+5. `../runnable/10-finite-temperature-effects/h2o-linear-response-polarizability.inp`
+
+This path walks through optical TDDFPT, sTDA, transition-potential XAS, XAS_TDP with GW2X, and a
+small linear-response polarizability calculation.
+
+## Finite-Temperature Methods
+
+1. `../runnable/10-finite-temperature-effects/h2o-nnp-committee-md.inp`
+2. `../runnable/10-finite-temperature-effects/h2o-nnp-biased-md.inp`
+3. `../runnable/10-finite-temperature-effects/h2o-pint-nve.inp`
+4. `../runnable/10-finite-temperature-effects/h2o-pint-pile.inp`
+5. `../runnable/10-finite-temperature-effects/h2o-vibrational-analysis.inp`
+
+This path covers committee neural-network potentials, a biased NNP trajectory, path-integral MD,
+and a static vibrational analysis.

--- a/cp2k-made-simple/optional-workflows/README.md
+++ b/cp2k-made-simple/optional-workflows/README.md
@@ -4,14 +4,16 @@ Some snippets from the paper are better kept as fragments or larger workflows ra
 smoke-test inputs. The table records good candidates for future examples and the main reason they
 were not folded into the small runnable set.
 
-| topic | snippets | dependency or size note | possible follow-up |
-| --- | --- | --- | --- |
-| SIRIUS band-structure setup | 026, 027 | requires a CP2K build with SIRIUS and its accelerator/math stack | add a minimal SIRIUS input with an explicit build-requirements note |
-| Molecular GW | 028 | methodologically heavier than the water smoke tests | connect to the existing `../../gw/1_H2O_GW100/` example |
-| Periodic GW with k-points | 030, 031 | larger convergence space and more expensive settings | add a reduced companion to the existing GW examples if reviewers want one here |
-| BSE optical absorption | 060 | depends on a preceding GW-style setup and produces larger spectra | document as a staged workflow rather than a single smoke-test input |
-| Surface hopping with NEWTON-X | 062, 063 | needs an external trajectory driver workflow | keep as a method fragment unless a full external-workflow example is added |
-| Bosonic quantum solvation | 083, 084, 085 | specialized helium/low-temperature setup, less compact than the water PINT cases | consider a separate advanced finite-temperature example |
+| topic | snippets | related material | dependency or size note | possible follow-up |
+| --- | --- | --- | --- | --- |
+| SIRIUS band-structure setup | 026, 027 | [`tests/SIRIUS/regtest-1/N2.inp`](https://github.com/cp2k/cp2k/blob/master/tests/SIRIUS/regtest-1/N2.inp) | requires a CP2K build with SIRIUS and its math/accelerator dependencies | add a minimal SIRIUS input with an explicit build-requirements note |
+| Molecular GW | 028 | `../../gw/1_H2O_GW100/H2O_GW100_def2-QZVP.inp` | heavier than the water smoke tests and needs convergence choices that are method-specific | add a short bridge note from the paper snippet to the existing GW example |
+| Periodic GW with k-points | 030, 031 | `../../gw/3_3-atom_unit_cell_2d_WSe2_loose_parameters/GW.inp` | larger convergence space and more expensive settings | add a reduced companion only if reviewers want one in this folder |
+| BSE optical absorption | 060 | `../../rtbse/Ethene/rtbse.inp` | depends on a preceding excited-state setup and produces larger spectra | document as a staged workflow rather than a single smoke-test input |
+| Real-time XAS propagation | 070 | `../../rtp_field_xas/tutorial_rtp.ipynb` and `../../rtp_field_xas/Data/RTP.inp` | the full workflow uses precomputed XAS_TDP states and a custom basis file | keep the small Gaussian-field input runnable and point advanced users to the full tutorial |
+| Voronoi integration | 089 | `../paper-snippets/089-10-finite-temperature-effects-dft.inp` | useful output requires CP2K compiled with `__LIBVORI`; otherwise the `.voronoi` file is empty | keep as optional unless a LIBVORI-enabled smoke test is available |
+| Surface hopping with NEWTON-X | 062, 063 | [`tests/QS/regtest-gpw-9/h2o_NEWTONX.inp`](https://github.com/cp2k/cp2k/blob/master/tests/QS/regtest-gpw-9/h2o_NEWTONX.inp) | needs an external trajectory driver workflow | keep as a method fragment unless a full external-workflow example is added |
+| Bosonic quantum solvation | 083, 084, 085 | [`tests/Pimd/regtest-2/water_in_helium_nnp.inp`](https://github.com/cp2k/cp2k/blob/master/tests/Pimd/regtest-2/water_in_helium_nnp.inp) and [`tests/Pimd/regtest-1/he32_only.inp`](https://github.com/cp2k/cp2k/blob/master/tests/Pimd/regtest-1/he32_only.inp) | specialized helium/low-temperature setup, less compact than the water PINT cases | consider a separate advanced finite-temperature example |
 
 The current runnable set favors examples that complete quickly with a standard CP2K data directory.
 This optional list is a parking place for examples that are scientifically useful but need clearer

--- a/cp2k-made-simple/optional-workflows/README.md
+++ b/cp2k-made-simple/optional-workflows/README.md
@@ -1,0 +1,18 @@
+# Optional CP2K Made Simple Workflows
+
+Some snippets from the paper are better kept as fragments or larger workflows rather than compact
+smoke-test inputs. The table records good candidates for future examples and the main reason they
+were not folded into the small runnable set.
+
+| topic | snippets | dependency or size note | possible follow-up |
+| --- | --- | --- | --- |
+| SIRIUS band-structure setup | 026, 027 | requires a CP2K build with SIRIUS and its accelerator/math stack | add a minimal SIRIUS input with an explicit build-requirements note |
+| Molecular GW | 028 | methodologically heavier than the water smoke tests | connect to the existing `../../gw/1_H2O_GW100/` example |
+| Periodic GW with k-points | 030, 031 | larger convergence space and more expensive settings | add a reduced companion to the existing GW examples if reviewers want one here |
+| BSE optical absorption | 060 | depends on a preceding GW-style setup and produces larger spectra | document as a staged workflow rather than a single smoke-test input |
+| Surface hopping with NEWTON-X | 062, 063 | needs an external trajectory driver workflow | keep as a method fragment unless a full external-workflow example is added |
+| Bosonic quantum solvation | 083, 084, 085 | specialized helium/low-temperature setup, less compact than the water PINT cases | consider a separate advanced finite-temperature example |
+
+The current runnable set favors examples that complete quickly with a standard CP2K data directory.
+This optional list is a parking place for examples that are scientifically useful but need clearer
+build, data, or workflow assumptions before becoming small standalone inputs.

--- a/cp2k-made-simple/optional-workflows/README.md
+++ b/cp2k-made-simple/optional-workflows/README.md
@@ -1,19 +1,17 @@
 # Optional CP2K Made Simple Workflows
 
-Some snippets from the paper are better kept as fragments or larger workflows rather than compact
-smoke-test inputs. The table records good candidates for future examples and the main reason they
-were not folded into the small runnable set.
+Some snippets from the paper are better kept as fragments, larger workflows, or dependency-aware
+notes rather than compact smoke-test inputs. The table records good candidates for future examples
+and the main reason they were not folded into the small runnable set.
 
-| topic | snippets | related material | dependency or size note | possible follow-up |
+| topic | snippets | details | dependency or size note | possible follow-up |
 | --- | --- | --- | --- | --- |
-| SIRIUS band-structure setup | 026, 027 | [`tests/SIRIUS/regtest-1/N2.inp`](https://github.com/cp2k/cp2k/blob/master/tests/SIRIUS/regtest-1/N2.inp) | requires a CP2K build with SIRIUS and its math/accelerator dependencies | add a minimal SIRIUS input with an explicit build-requirements note |
-| Molecular GW | 028 | `../../gw/1_H2O_GW100/H2O_GW100_def2-QZVP.inp` | heavier than the water smoke tests and needs convergence choices that are method-specific | add a short bridge note from the paper snippet to the existing GW example |
-| Periodic GW with k-points | 030, 031 | `../../gw/3_3-atom_unit_cell_2d_WSe2_loose_parameters/GW.inp` | larger convergence space and more expensive settings | add a reduced companion only if reviewers want one in this folder |
-| BSE optical absorption | 060 | `../../rtbse/Ethene/rtbse.inp` | depends on a preceding excited-state setup and produces larger spectra | document as a staged workflow rather than a single smoke-test input |
-| Real-time XAS propagation | 070 | `../../rtp_field_xas/tutorial_rtp.ipynb` and `../../rtp_field_xas/Data/RTP.inp` | the full workflow uses precomputed XAS_TDP states and a custom basis file | keep the small Gaussian-field input runnable and point advanced users to the full tutorial |
-| Voronoi integration | 089 | `../paper-snippets/089-10-finite-temperature-effects-dft.inp` | useful output requires CP2K compiled with `__LIBVORI`; otherwise the `.voronoi` file is empty | keep as optional unless a LIBVORI-enabled smoke test is available |
-| Surface hopping with NEWTON-X | 062, 063 | [`tests/QS/regtest-gpw-9/h2o_NEWTONX.inp`](https://github.com/cp2k/cp2k/blob/master/tests/QS/regtest-gpw-9/h2o_NEWTONX.inp) | needs an external trajectory driver workflow | keep as a method fragment unless a full external-workflow example is added |
-| Bosonic quantum solvation | 083, 084, 085 | [`tests/Pimd/regtest-2/water_in_helium_nnp.inp`](https://github.com/cp2k/cp2k/blob/master/tests/Pimd/regtest-2/water_in_helium_nnp.inp) and [`tests/Pimd/regtest-1/he32_only.inp`](https://github.com/cp2k/cp2k/blob/master/tests/Pimd/regtest-1/he32_only.inp) | specialized helium/low-temperature setup, less compact than the water PINT cases | consider a separate advanced finite-temperature example |
+| SIRIUS band-structure setup | 026, 027 | [`sirius/`](sirius/) | requires a CP2K build with SIRIUS and its math/accelerator dependencies | add a minimal SIRIUS input with an explicit build-requirements note |
+| GW and BSE workflows | 028, 030, 031, 060 | [`gw-bse/`](gw-bse/) | heavier than the water smoke tests and needs convergence choices that are method-specific | keep bridges to existing examples unless a reduced teaching input is requested |
+| Real-time XAS propagation | 070 | [`real-time-xas/`](real-time-xas/) | the full workflow uses precomputed XAS_TDP states and a custom basis file | keep the small Gaussian-field input runnable and point advanced users to the full tutorial |
+| Voronoi integration | 089 | [`voronoi/`](voronoi/) | useful output requires CP2K compiled with `__LIBVORI`; otherwise the `.voronoi` file is empty | keep as optional unless a LIBVORI-enabled smoke test is available |
+| Surface hopping with NEWTON-X | 062, 063 | [`newton-x/`](newton-x/) | needs an external trajectory driver workflow | keep as a method fragment unless a full external-workflow example is added |
+| Bosonic quantum solvation | 083, 084, 085 | [`helium-pint/`](helium-pint/) | specialized helium/low-temperature setup, less compact than the water PINT cases | consider a separate advanced finite-temperature example |
 
 The current runnable set favors examples that complete quickly with a standard CP2K data directory.
 This optional list is a parking place for examples that are scientifically useful but need clearer

--- a/cp2k-made-simple/optional-workflows/gw-bse/README.md
+++ b/cp2k-made-simple/optional-workflows/gw-bse/README.md
@@ -1,0 +1,14 @@
+# GW and BSE Workflows
+
+The CP2K Made Simple snippets for molecular GW, periodic GW, and BSE are useful pointers, but the
+scientific workflow is less compact than a single small smoke-test input. These methods usually
+need basis-set, empty-state, grid, and spectrum-convergence choices that should be made deliberately.
+
+Related complete examples already exist in this repository:
+
+- Molecular GW: [`gw/1_H2O_GW100/H2O_GW100_def2-QZVP.inp`](../../../gw/1_H2O_GW100/H2O_GW100_def2-QZVP.inp)
+- Periodic GW: [`gw/3_3-atom_unit_cell_2d_WSe2_loose_parameters/GW.inp`](../../../gw/3_3-atom_unit_cell_2d_WSe2_loose_parameters/GW.inp)
+- BSE optical absorption: [`rtbse/Ethene/rtbse.inp`](../../../rtbse/Ethene/rtbse.inp)
+
+For this folder, these are better kept as workflow bridges rather than duplicated toy inputs.
+Adding reduced teaching inputs would be valuable, but only with explicit convergence notes.

--- a/cp2k-made-simple/optional-workflows/helium-pint/README.md
+++ b/cp2k-made-simple/optional-workflows/helium-pint/README.md
@@ -1,0 +1,13 @@
+# Bosonic Helium PINT Workflows
+
+The bosonic quantum-solvation snippets in the paper point beyond the compact water PINT examples in
+`../../runnable/10-finite-temperature-effects/`. They require a more specialized low-temperature
+helium setup and are therefore not part of the small runnable smoke-test set.
+
+Useful CP2K regression-test references are:
+
+- [`tests/Pimd/regtest-2/water_in_helium_nnp.inp`](https://github.com/cp2k/cp2k/blob/master/tests/Pimd/regtest-2/water_in_helium_nnp.inp)
+- [`tests/Pimd/regtest-1/he32_only.inp`](https://github.com/cp2k/cp2k/blob/master/tests/Pimd/regtest-1/he32_only.inp)
+
+A future standalone example should explain the helium model, the NNP data assumptions, and the
+temperature/path-integral settings rather than just wrapping the snippets in a minimal input.

--- a/cp2k-made-simple/optional-workflows/newton-x/README.md
+++ b/cp2k-made-simple/optional-workflows/newton-x/README.md
@@ -1,0 +1,11 @@
+# NEWTON-X Surface-Hopping Workflow
+
+The surface-hopping snippets in the paper are method fragments for a coupled CP2K/NEWTON-X
+workflow. A self-contained CP2K input is not enough to demonstrate the complete calculation because
+the trajectory driver and file exchange are external to a normal single CP2K run.
+
+The closest CP2K-side regression-test reference is
+[`tests/QS/regtest-gpw-9/h2o_NEWTONX.inp`](https://github.com/cp2k/cp2k/blob/master/tests/QS/regtest-gpw-9/h2o_NEWTONX.inp).
+
+This is a good candidate for a workflow document if a future example can include the external
+driver steps and expected file handoff explicitly.

--- a/cp2k-made-simple/optional-workflows/real-time-xas/README.md
+++ b/cp2k-made-simple/optional-workflows/real-time-xas/README.md
@@ -1,0 +1,15 @@
+# Real-Time XAS Workflow
+
+The runnable set includes a compact Gaussian-field real-time propagation input:
+
+- [`runnable/08-x-ray-spectroscopy/h2o-real-time-gaussian-field.inp`](../../runnable/08-x-ray-spectroscopy/h2o-real-time-gaussian-field.inp)
+
+The fuller real-time XAS workflow is more staged: it can use precomputed XAS_TDP states and a
+custom basis file, then propagate the response with field settings chosen for the spectrum of
+interest. Existing tutorial material in this repository is the better starting point:
+
+- [`rtp_field_xas/tutorial_rtp.ipynb`](../../../rtp_field_xas/tutorial_rtp.ipynb)
+- [`rtp_field_xas/Data/RTP.inp`](../../../rtp_field_xas/Data/RTP.inp)
+
+The small runnable input is therefore a smoke-testable bridge, while the tutorial remains the
+right place for the production-style workflow.

--- a/cp2k-made-simple/optional-workflows/sirius/README.md
+++ b/cp2k-made-simple/optional-workflows/sirius/README.md
@@ -1,0 +1,12 @@
+# SIRIUS Band-Structure Setup
+
+The SIRIUS snippets in the paper show the CP2K input sections needed for a SIRIUS-backed
+band-structure calculation. A compact standalone example is not included in the runnable set
+because it requires a CP2K build with SIRIUS and the corresponding math and accelerator
+dependencies.
+
+The closest CP2K regression-test reference is
+[`tests/SIRIUS/regtest-1/N2.inp`](https://github.com/cp2k/cp2k/blob/master/tests/SIRIUS/regtest-1/N2.inp).
+
+If this becomes a full example, it should state the required CP2K build features and avoid implying
+that the input works with a default QUICKSTEP-only executable.

--- a/cp2k-made-simple/optional-workflows/voronoi/README.md
+++ b/cp2k-made-simple/optional-workflows/voronoi/README.md
@@ -1,0 +1,13 @@
+# Voronoi Integration
+
+The Voronoi snippet is useful, but it depends on CP2K being compiled with LIBVORI support. With a
+build that lacks `__LIBVORI`, CP2K can still complete the calculation while the `.voronoi` output
+is empty, which makes it a poor default smoke test.
+
+Related material:
+
+- Paper snippet: [`paper-snippets/089-10-finite-temperature-effects-dft.inp`](../../paper-snippets/089-10-finite-temperature-effects-dft.inp)
+- Nearby runnable inputs: [`h2o-periodic-efield.inp`](../../runnable/10-finite-temperature-effects/h2o-periodic-efield.inp) and [`h2o-linear-response-polarizability.inp`](../../runnable/10-finite-temperature-effects/h2o-linear-response-polarizability.inp)
+
+A future runnable Voronoi input should either require a LIBVORI-enabled CP2K build explicitly or
+include a test that verifies non-empty Voronoi output.

--- a/cp2k-made-simple/runnable/05-magnetic-resonance/h2o-hyperfine-coupling.inp
+++ b/cp2k-made-simple/runnable/05-magnetic-resonance/h2o-hyperfine-coupling.inp
@@ -1,0 +1,78 @@
+! All-electron GAPW water-cation hyperfine coupling tensor calculation.
+! Derived from CP2K Made Simple snippet 055.
+! Reference: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+
+&GLOBAL
+  PRINT_LEVEL MEDIUM
+  PROJECT h2o-hyperfine-coupling
+  RUN_TYPE ENERGY
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD QS
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_SET
+    CHARGE 1
+    LSD
+    MULTIPLICITY 2
+    POTENTIAL_FILE_NAME POTENTIAL
+    &MGRID
+      COMMENSURATE
+      CUTOFF 400
+      NGRIDS 5
+      REL_CUTOFF 50
+    &END MGRID
+    &POISSON
+      PERIODIC NONE
+      POISSON ANALYTIC
+      &WAVELET
+      &END WAVELET
+    &END POISSON
+    &PRINT
+      &HYPERFINE_COUPLING_TENSOR
+      &END HYPERFINE_COUPLING_TENSOR
+    &END PRINT
+    &QS
+      EPS_DEFAULT 1.0E-14
+      METHOD GAPW
+    &END QS
+    &SCF
+      EPS_SCF 1.0E-5
+      MAX_SCF 40
+      SCF_GUESS ATOMIC
+      &DIAGONALIZATION T
+        ALGORITHM STANDARD
+        MAX_ITER 20
+      &END DIAGONALIZATION
+      &MIXING
+      &END MIXING
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PBE
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 5.0 5.0 5.0
+      PERIODIC NONE
+    &END CELL
+    &COORD
+      O   0.000000   0.000000  -0.065587
+      H   0.000000  -0.757136   0.520545
+      H   0.000000   0.757136   0.520545
+    &END COORD
+    &KIND O
+      BASIS_SET DZVP-ALL
+      POTENTIAL ALL
+    &END KIND
+    &KIND H
+      BASIS_SET DZVP-ALL
+      POTENTIAL ALL
+    &END KIND
+    &TOPOLOGY
+      &CENTER_COORDINATES
+      &END CENTER_COORDINATES
+    &END TOPOLOGY
+  &END SUBSYS
+&END FORCE_EVAL

--- a/cp2k-made-simple/runnable/08-x-ray-spectroscopy/h2o-real-time-gaussian-field.inp
+++ b/cp2k-made-simple/runnable/08-x-ray-spectroscopy/h2o-real-time-gaussian-field.inp
@@ -1,0 +1,98 @@
+! Quickstep/GPW water real-time propagation with a Gaussian electric-field pulse.
+! Derived from CP2K Made Simple snippet 070.
+! Reference: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+
+&GLOBAL
+  PRINT_LEVEL LOW
+  PROJECT h2o-real-time-gaussian-field
+  RUN_TYPE RT_PROPAGATION
+&END GLOBAL
+
+&MOTION
+  &MD
+    STEPS 2
+    TIMESTEP [au_t] 0.1
+  &END MD
+&END MOTION
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME BASIS_MOLOPT
+    POTENTIAL_FILE_NAME POTENTIAL
+    &EFIELD
+      ENVELOP GAUSSIAN
+      INTENSITY 3.5E10
+      POLARISATION 0 0 1
+      VEC_POT_INITIAL 0.0 0.0 0.0
+      &GAUSSIAN_ENV
+        SIGMA [fs] 0.002340
+        T0 [fs] 0.006240
+      &END GAUSSIAN_ENV
+    &END EFIELD
+    &MGRID
+      CUTOFF 200
+    &END MGRID
+    &POISSON
+      PERIODIC NONE
+      POISSON_SOLVER WAVELET
+    &END POISSON
+    &PRINT
+      &MOMENTS
+        PERIODIC F
+      &END MOMENTS
+    &END PRINT
+    &QS
+      METHOD GPW
+    &END QS
+    &REAL_TIME_PROPAGATION
+      EPS_ITER 1.0E-9
+      EXP_ACCURACY 1.0E-15
+      INITIAL_WFN SCF_WFN
+      MAT_EXP TAYLOR
+      MAX_ITER 100
+      PROPAGATOR ETRS
+      VELOCITY_GAUGE T
+      VG_COM_NL T
+      &PRINT
+        &FIELD
+        &END FIELD
+        &E_CONSTITUENTS
+        &END E_CONSTITUENTS
+        &CURRENT_INT
+        &END CURRENT_INT
+      &END PRINT
+    &END REAL_TIME_PROPAGATION
+    &SCF
+      MAX_SCF 20
+      SCF_GUESS ATOMIC
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL PADE
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 7.0 7.0 7.0
+      PERIODIC NONE
+    &END CELL
+    &COORD
+      O  0.000000  0.000000 -0.065587 H2O
+      H  0.000000 -0.757136  0.520545 H2O
+      H  0.000000  0.757136  0.520545 H2O
+    &END COORD
+    &KIND O
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-PADE-q6
+    &END KIND
+    &KIND H
+      BASIS_SET DZVP-MOLOPT-GTH
+      POTENTIAL GTH-PADE-q1
+    &END KIND
+    &TOPOLOGY
+      &CENTER_COORDINATES
+      &END CENTER_COORDINATES
+    &END TOPOLOGY
+  &END SUBSYS
+&END FORCE_EVAL

--- a/cp2k-made-simple/runnable/10-finite-temperature-effects/h2o-orbital-localization.inp
+++ b/cp2k-made-simple/runnable/10-finite-temperature-effects/h2o-orbital-localization.inp
@@ -1,0 +1,57 @@
+! Quickstep/GPW water orbital-localization calculation with Wannier centers.
+! Derived from CP2K Made Simple snippet 088.
+! Reference: The CP2K Program Package Made Simple, DOI: 10.1021/acs.jpcb.5c05851
+
+&GLOBAL
+  PRINT_LEVEL LOW
+  PROJECT h2o-orbital-localization
+  RUN_TYPE ENERGY
+&END GLOBAL
+
+&FORCE_EVAL
+  METHOD Quickstep
+  &DFT
+    BASIS_SET_FILE_NAME GTH_BASIS_SETS
+    POTENTIAL_FILE_NAME GTH_POTENTIALS
+    &LOCALIZE
+      EPS_LOCALIZATION 1.0E-10
+      METHOD L1SD
+      &PRINT
+        &WANNIER_CENTERS
+        &END WANNIER_CENTERS
+      &END PRINT
+    &END LOCALIZE
+    &MGRID
+      CUTOFF 200
+    &END MGRID
+    &QS
+    &END QS
+    &SCF
+      EPS_SCF 1.0E-6
+      MAX_SCF 20
+      SCF_GUESS ATOMIC
+    &END SCF
+    &XC
+      &XC_FUNCTIONAL BLYP
+      &END XC_FUNCTIONAL
+    &END XC
+  &END DFT
+  &SUBSYS
+    &CELL
+      ABC 7.0 7.0 7.0
+    &END CELL
+    &COORD
+      O  0.000000  0.000000 -0.065587
+      H  0.000000 -0.757136  0.520545
+      H  0.000000  0.757136  0.520545
+    &END COORD
+    &KIND O
+      BASIS_SET DZVP-GTH
+      POTENTIAL GTH-BLYP-q6
+    &END KIND
+    &KIND H
+      BASIS_SET DZVP-GTH
+      POTENTIAL GTH-BLYP-q1
+    &END KIND
+  &END SUBSYS
+&END FORCE_EVAL

--- a/cp2k-made-simple/runnable/README.md
+++ b/cp2k-made-simple/runnable/README.md
@@ -118,6 +118,19 @@ To run only a representative quick subset with numeric output checks:
 python3 run_smoke_tests.py --cp2k /path/to/cp2k.psmp --data-dir /path/to/cp2k/data --quick
 ```
 
+To check the manifest and generated README before review:
+
+```bash
+python3 validate_manifest.py
+python3 generate_readme.py --check
+```
+
+To run one selected input:
+
+```bash
+python3 run_smoke_tests.py --cp2k /path/to/cp2k.psmp --data-dir /path/to/cp2k/data --only '05-magnetic-resonance/h2o-hyperfine-coupling.inp'
+```
+
 Use `--jobs N` only when the machine has enough cores and memory for several independent CP2K
 runs. Each input is executed in its own work directory.
 

--- a/cp2k-made-simple/runnable/README.md
+++ b/cp2k-made-simple/runnable/README.md
@@ -11,84 +11,89 @@ small standalone calculations. The directory names follow the paper chapters.
 
 The examples are grouped by the paper chapters. Local test results are also recorded in
 `manifest.tsv`, which includes the marker and reference value used by `run_smoke_tests.py`.
+The tables below are generated from `manifest.tsv`; after changing the manifest, run
+`python3 generate_readme.py`.
 
+<!-- BEGIN GENERATED EXAMPLES -->
 ### 2. Total Energy and Force Methods
 
-| input | topic | based on snippets | local test result |
-| --- | --- | --- | --- |
-| `02-total-energy-and-force-methods/h2o-gpw-pbe.inp` | GPW/PBE single point | 001, 002 | energy -17.212337144585153 Ha |
-| `02-total-energy-and-force-methods/h2o-gpw-ot.inp` | GPW/PBE with OT | 001, 005, 006 | energy -17.212337144506982 Ha |
-| `02-total-energy-and-force-methods/h2o-gpw-smearing.inp` | GPW/PBE with smearing | 001, 005 | energy -17.212334309139813 Ha |
-| `02-total-energy-and-force-methods/h2o-gapw-all-electron.inp` | all-electron GAPW/PBE | 003, 004 | energy -76.238068224190314 Ha |
-| `02-total-energy-and-force-methods/h2o-pbe0-admm.inp` | hybrid DFT with ADMM | 010, 011, 012, 013 | energy -17.151344159601688 Ha |
-| `02-total-energy-and-force-methods/h2o-dft-plus-u.inp` | DFT+U setup | 022, 023, 024, 025 | energy -17.180669501745012 Ha |
-| `02-total-energy-and-force-methods/h2o-ri-mp2.inp` | RI-MP2 correlation | 016, 017 | energy -17.170315778164436 Ha |
+| input | topic | based on snippets | local test result | quick |
+| --- | --- | --- | --- | --- |
+| `02-total-energy-and-force-methods/h2o-gpw-pbe.inp` | GPW/PBE single point | 001, 002 | energy -17.212337144585153 Ha | yes |
+| `02-total-energy-and-force-methods/h2o-gpw-ot.inp` | GPW/PBE with OT | 001, 005, 006 | energy -17.212337144506982 Ha | - |
+| `02-total-energy-and-force-methods/h2o-gpw-smearing.inp` | GPW/PBE with diagonalization and smearing | 001, 005 | energy -17.212334309139813 Ha | - |
+| `02-total-energy-and-force-methods/h2o-gapw-all-electron.inp` | all-electron GAPW/PBE | 003, 004 | energy -76.238068224190314 Ha | - |
+| `02-total-energy-and-force-methods/h2o-pbe0-admm.inp` | hybrid DFT with ADMM | 010, 011, 012, 013 | energy -17.151344159601688 Ha | - |
+| `02-total-energy-and-force-methods/h2o-dft-plus-u.inp` | DFT+U setup | 022, 023, 024, 025 | energy -17.180669501745012 Ha | yes |
+| `02-total-energy-and-force-methods/h2o-ri-mp2.inp` | RI-MP2 correlation | 016, 017 | energy -17.170315778164436 Ha | - |
 
 ### 3. Electronic Band Structure
 
-| input | topic | based on snippets | local test result |
-| --- | --- | --- | --- |
-| `03-electronic-band-structure/diamond-kpoints-band-structure.inp` | k-point band output | 007, 008, 030, 031 | energy -45.498947901745879 Ha |
+| input | topic | based on snippets | local test result | quick |
+| --- | --- | --- | --- | --- |
+| `03-electronic-band-structure/diamond-kpoints-band-structure.inp` | k-point band output | 007, 008, 030, 031 | energy -45.498947901745879 Ha | - |
 
 ### 4. Embedding Methods
 
-| input | topic | based on snippets | local test result |
-| --- | --- | --- | --- |
-| `04-embedding-methods/h2o-sccs-solvation.inp` | SCCS implicit solvation | 032, 033, 034, 035 | energy -17.226540497029429 Ha |
-| `04-embedding-methods/h2o-qmmm-gaussian.inp` | Gaussian electrostatic QMMM | 036, 037, 038, 039 | energy -16.860414497766239 Ha |
-| `04-embedding-methods/ch3oh-resp-charges.inp` | RESP charge fitting | 040, 041, 042 | energy -23.909587912298466 Ha; RESP RMS 7.55141E-05 |
-| `04-embedding-methods/h2o-h2-dfet.inp` | density functional embedding | 043, 044, 045, 046, 047, 048, 049 | energy -18.321636385557674 Ha |
+| input | topic | based on snippets | local test result | quick |
+| --- | --- | --- | --- | --- |
+| `04-embedding-methods/h2o-sccs-solvation.inp` | SCCS implicit solvation | 032, 033, 034, 035 | energy -17.226540497029429 Ha | - |
+| `04-embedding-methods/h2o-qmmm-gaussian.inp` | Gaussian electrostatic QMMM | 036, 037, 038, 039 | energy -16.860414497766239 Ha | yes |
+| `04-embedding-methods/ch3oh-resp-charges.inp` | RESP charge fitting | 040, 041, 042 | energy -23.909587912298466 Ha; RESP RMS 7.55141E-05 | - |
+| `04-embedding-methods/h2o-h2-dfet.inp` | density functional embedding | 043, 044, 045, 046, 047, 048, 049 | energy -18.321636385557674 Ha | - |
 
 ### 5. Magnetic Resonance
 
-| input | topic | based on snippets | local test result |
-| --- | --- | --- | --- |
-| `05-magnetic-resonance/h2o-nmr-linear-response.inp` | NMR linear response | 050, 051, 052, 053 | shielding checksum 0.605916E+02 |
-| `05-magnetic-resonance/no2-epr-g-tensor.inp` | EPR g-tensor linear response | 050, 054 | EPR checksum -0.130768E-02 |
-| `05-magnetic-resonance/h2o-hyperfine-coupling.inp` | EPR hyperfine coupling tensor | 055 | O Sca-Rel A_iso -118.2292921806 MHz; energy -75.901123242692378 Ha |
+| input | topic | based on snippets | local test result | quick |
+| --- | --- | --- | --- | --- |
+| `05-magnetic-resonance/h2o-nmr-linear-response.inp` | NMR linear response | 050, 051, 052, 053 | shielding checksum 0.605916E+02 | yes |
+| `05-magnetic-resonance/no2-epr-g-tensor.inp` | EPR g-tensor linear response | 050, 054 | EPR checksum -0.130768E-02 | - |
+| `05-magnetic-resonance/h2o-hyperfine-coupling.inp` | EPR hyperfine coupling tensor | 055 | O Sca-Rel A_iso -118.2292921806 MHz; energy -75.901123242692378 Ha | - |
 
 ### 6. Optical Spectroscopy
 
-| input | topic | based on snippets | local test result |
-| --- | --- | --- | --- |
-| `06-optical-spectroscopy/h2o-tddfpt.inp` | linear-response TDDFPT | 056 | first excitation 8.43471 eV |
-| `06-optical-spectroscopy/h2o-stda-tddfpt.inp` | sTDA-TDDFPT | 057, 058, 059 | first excitation 7.86094 eV |
+| input | topic | based on snippets | local test result | quick |
+| --- | --- | --- | --- | --- |
+| `06-optical-spectroscopy/h2o-tddfpt.inp` | linear-response TDDFPT | 056 | first excitation 8.43471 eV | - |
+| `06-optical-spectroscopy/h2o-stda-tddfpt.inp` | sTDA-TDDFPT | 057, 058, 059 | first excitation 7.86094 eV | yes |
 
 ### 7. Excited-State Dynamics
 
-| input | topic | based on snippets | local test result |
-| --- | --- | --- | --- |
-| `07-excited-state-dynamics/h2o-real-time-propagation.inp` | real-time propagation | 061, 069 | final total energy -17.17816551662580 Ha |
+| input | topic | based on snippets | local test result | quick |
+| --- | --- | --- | --- | --- |
+| `07-excited-state-dynamics/h2o-real-time-propagation.inp` | real-time propagation | 061, 069 | final total energy -17.17816551662580 Ha | - |
 
 ### 8. X-Ray Spectroscopy
 
-| input | topic | based on snippets | local test result |
-| --- | --- | --- | --- |
-| `08-x-ray-spectroscopy/co-xas-transition-potential.inp` | XAS transition potential | 064 | energy -92.844208496940453 Ha |
-| `08-x-ray-spectroscopy/h2o-xastdp-gw2x.inp` | XAS_TDP with GW2X correction | 065, 066, 067 | first XAS excitation 538.170258 eV; energy -75.956287566248847 Ha |
-| `08-x-ray-spectroscopy/h2o-real-time-gaussian-field.inp` | real-time propagation with Gaussian field | 070 | final RTP energy -17.17816621169307 Ha |
+| input | topic | based on snippets | local test result | quick |
+| --- | --- | --- | --- | --- |
+| `08-x-ray-spectroscopy/co-xas-transition-potential.inp` | XAS transition potential | 064 | energy -92.844208496940453 Ha | - |
+| `08-x-ray-spectroscopy/h2o-xastdp-gw2x.inp` | XAS_TDP with GW2X correction | 065, 066, 067 | first XAS excitation 538.170258 eV; energy -75.956287566248847 Ha | - |
+| `08-x-ray-spectroscopy/h2o-real-time-gaussian-field.inp` | real-time propagation with Gaussian field | 070 | final RTP energy -17.17816621169307 Ha | yes |
 
 ### 9. Energy Decomposition Analysis
 
-| input | topic | based on snippets | local test result |
-| --- | --- | --- | --- |
-| `09-energy-decomposition-analysis/h2o-almo-eda.inp` | ALMO energy decomposition | 071, 073 | energy -85.963743073058524 Ha |
-| `09-energy-decomposition-analysis/lif-almo-ionic.inp` | ionic ALMO electron assignment | 072, 073 | energy -127.539319485670845 Ha |
+| input | topic | based on snippets | local test result | quick |
+| --- | --- | --- | --- | --- |
+| `09-energy-decomposition-analysis/h2o-almo-eda.inp` | ALMO energy decomposition | 071, 073 | energy -85.963743073058524 Ha | - |
+| `09-energy-decomposition-analysis/lif-almo-ionic.inp` | ionic ALMO electron assignment | 072, 073 | energy -127.539319485670845 Ha | - |
 
 ### 10. Finite-Temperature Effects
 
-| input | topic | based on snippets | local test result |
-| --- | --- | --- | --- |
-| `10-finite-temperature-effects/h2o-nnp-committee-md.inp` | committee NNP molecular dynamics | 074, 075, 076 | final energy 58.648809523054418 Ha |
-| `10-finite-temperature-effects/h2o-nnp-biased-md.inp` | biased committee NNP molecular dynamics | 074, 075, 076, 077 | final energy 58.661222155637667 Ha |
-| `10-finite-temperature-effects/h2o-pint-nve.inp` | path-integral molecular dynamics | 078 | final PINT energy -17.137402749384318 Ha |
-| `10-finite-temperature-effects/h2o-pint-nose.inp` | PINT with Nose thermostat | 078, 079 | final PINT energy -17.129535930553633 Ha |
-| `10-finite-temperature-effects/h2o-pint-pile.inp` | PINT with PILE thermostat | 078, 080 | final PINT energy -68.549498536850606 Ha |
-| `10-finite-temperature-effects/h2o-pint-qtb.inp` | PINT with QTB thermostat | 078, 081 | final PINT energy -68.549621077706419 Ha |
-| `10-finite-temperature-effects/h2o-vibrational-analysis.inp` | vibrational analysis | 086 | first frequencies 0.000000 cm^-1 |
-| `10-finite-temperature-effects/h2o-periodic-efield.inp` | periodic electric field | 087, 090 | energy -16.553933618515682 Ha |
-| `10-finite-temperature-effects/h2o-orbital-localization.inp` | orbital localization and Wannier centers | 088 | localization converged in 26 iterations; energy -17.186709451452117 Ha |
-| `10-finite-temperature-effects/h2o-linear-response-polarizability.inp` | linear-response polarizability | 091 | polarizability xx/yy/zz 0.006179870499/0.958172935260/0.397344896793 ang^3 |
+| input | topic | based on snippets | local test result | quick |
+| --- | --- | --- | --- | --- |
+| `10-finite-temperature-effects/h2o-nnp-committee-md.inp` | committee NNP molecular dynamics | 074, 075, 076 | final energy 58.648809523054418 Ha | yes |
+| `10-finite-temperature-effects/h2o-nnp-biased-md.inp` | biased committee NNP molecular dynamics | 074, 075, 076, 077 | final energy 58.661222155637667 Ha | - |
+| `10-finite-temperature-effects/h2o-pint-nve.inp` | path-integral molecular dynamics | 078 | final PINT energy -17.137402749384318 Ha | - |
+| `10-finite-temperature-effects/h2o-pint-nose.inp` | PINT with Nose thermostat | 078, 079 | final PINT energy -17.129535930553633 Ha | - |
+| `10-finite-temperature-effects/h2o-pint-pile.inp` | PINT with PILE thermostat | 078, 080 | final PINT energy -68.549498536850606 Ha | - |
+| `10-finite-temperature-effects/h2o-pint-qtb.inp` | PINT with QTB thermostat | 078, 081 | final PINT energy -68.549621077706419 Ha | - |
+| `10-finite-temperature-effects/h2o-vibrational-analysis.inp` | vibrational analysis | 086 | first frequencies 0.000000 cm^-1 | - |
+| `10-finite-temperature-effects/h2o-periodic-efield.inp` | periodic electric field | 087, 090 | energy -16.553933618515682 Ha | - |
+| `10-finite-temperature-effects/h2o-orbital-localization.inp` | orbital localization and Wannier centers | 088 | localization converged in 26 iterations; energy -17.186709451452117 Ha | yes |
+| `10-finite-temperature-effects/h2o-linear-response-polarizability.inp` | linear-response polarizability | 091 | polarizability xx/yy/zz 0.006179870499/0.958172935260/0.397344896793 ang^3 | yes |
+
+<!-- END GENERATED EXAMPLES -->
 
 Run from this directory, for example:
 

--- a/cp2k-made-simple/runnable/README.md
+++ b/cp2k-made-simple/runnable/README.md
@@ -25,11 +25,13 @@ small standalone calculations. The directory names follow the paper chapters.
 | `04-embedding-methods/h2o-h2-dfet.inp` | density functional embedding | 043, 044, 045, 046, 047, 048, 049 | energy -18.321636385557674 Ha |
 | `05-magnetic-resonance/h2o-nmr-linear-response.inp` | NMR linear response | 050, 051, 052, 053 | shielding checksum 0.605916E+02 |
 | `05-magnetic-resonance/no2-epr-g-tensor.inp` | EPR g-tensor linear response | 050, 054 | EPR checksum -0.130768E-02 |
+| `05-magnetic-resonance/h2o-hyperfine-coupling.inp` | EPR hyperfine coupling tensor | 055 | O Sca-Rel A_iso -118.2292921806 MHz; energy -75.901123242692378 Ha |
 | `06-optical-spectroscopy/h2o-tddfpt.inp` | linear-response TDDFPT | 056 | first excitation 8.43471 eV |
 | `06-optical-spectroscopy/h2o-stda-tddfpt.inp` | sTDA-TDDFPT | 057, 058, 059 | first excitation 7.86094 eV |
 | `07-excited-state-dynamics/h2o-real-time-propagation.inp` | real-time propagation | 061, 069 | final total energy -17.17816551662580 Ha |
 | `08-x-ray-spectroscopy/co-xas-transition-potential.inp` | XAS transition potential | 064 | energy -92.844208496940453 Ha |
 | `08-x-ray-spectroscopy/h2o-xastdp-gw2x.inp` | XAS_TDP with GW2X correction | 065, 066, 067 | first XAS excitation 538.170258 eV; energy -75.956287566248847 Ha |
+| `08-x-ray-spectroscopy/h2o-real-time-gaussian-field.inp` | real-time propagation with Gaussian field | 070 | final RTP energy -17.17816621169307 Ha |
 | `09-energy-decomposition-analysis/h2o-almo-eda.inp` | ALMO energy decomposition | 071, 073 | energy -85.963743073058524 Ha |
 | `09-energy-decomposition-analysis/lif-almo-ionic.inp` | ionic ALMO electron assignment | 072, 073 | energy -127.539319485670845 Ha |
 | `10-finite-temperature-effects/h2o-nnp-committee-md.inp` | committee NNP molecular dynamics | 074, 075, 076 | final energy 58.648809523054418 Ha |
@@ -40,6 +42,7 @@ small standalone calculations. The directory names follow the paper chapters.
 | `10-finite-temperature-effects/h2o-pint-qtb.inp` | PINT with QTB thermostat | 078, 081 | final PINT energy -68.549621077706419 Ha |
 | `10-finite-temperature-effects/h2o-vibrational-analysis.inp` | vibrational analysis | 086 | first frequencies 0.000000 cm^-1 |
 | `10-finite-temperature-effects/h2o-periodic-efield.inp` | periodic electric field | 087, 090 | energy -16.553933618515682 Ha |
+| `10-finite-temperature-effects/h2o-orbital-localization.inp` | orbital localization and Wannier centers | 088 | localization converged in 26 iterations; energy -17.186709451452117 Ha |
 | `10-finite-temperature-effects/h2o-linear-response-polarizability.inp` | linear-response polarizability | 091 | polarizability xx/yy/zz 0.006179870499/0.958172935260/0.397344896793 ang^3 |
 
 Run from this directory, for example:
@@ -49,6 +52,9 @@ CP2K_DATA_DIR=/path/to/cp2k/data cp2k.psmp -i 02-total-energy-and-force-methods/
 ```
 
 When CP2K has been installed with a configured data directory, `CP2K_DATA_DIR` is not needed.
+For reproducible quick checks, set `OMP_NUM_THREADS=1` and run each example in a separate work
+directory or with a unique output file name. The inputs are small enough for serial execution, but
+`cp2k.psmp` is also fine when used with a modest MPI/OpenMP layout.
 
 To smoke-test the complete set:
 

--- a/cp2k-made-simple/runnable/README.md
+++ b/cp2k-made-simple/runnable/README.md
@@ -9,6 +9,11 @@ small standalone calculations. The directory names follow the paper chapters.
 
 ## Examples
 
+The examples are grouped by the paper chapters. Local test results are also recorded in
+`manifest.tsv`, which includes the marker and reference value used by `run_smoke_tests.py`.
+
+### 2. Total Energy and Force Methods
+
 | input | topic | based on snippets | local test result |
 | --- | --- | --- | --- |
 | `02-total-energy-and-force-methods/h2o-gpw-pbe.inp` | GPW/PBE single point | 001, 002 | energy -17.212337144585153 Ha |
@@ -18,22 +23,62 @@ small standalone calculations. The directory names follow the paper chapters.
 | `02-total-energy-and-force-methods/h2o-pbe0-admm.inp` | hybrid DFT with ADMM | 010, 011, 012, 013 | energy -17.151344159601688 Ha |
 | `02-total-energy-and-force-methods/h2o-dft-plus-u.inp` | DFT+U setup | 022, 023, 024, 025 | energy -17.180669501745012 Ha |
 | `02-total-energy-and-force-methods/h2o-ri-mp2.inp` | RI-MP2 correlation | 016, 017 | energy -17.170315778164436 Ha |
+
+### 3. Electronic Band Structure
+
+| input | topic | based on snippets | local test result |
+| --- | --- | --- | --- |
 | `03-electronic-band-structure/diamond-kpoints-band-structure.inp` | k-point band output | 007, 008, 030, 031 | energy -45.498947901745879 Ha |
+
+### 4. Embedding Methods
+
+| input | topic | based on snippets | local test result |
+| --- | --- | --- | --- |
 | `04-embedding-methods/h2o-sccs-solvation.inp` | SCCS implicit solvation | 032, 033, 034, 035 | energy -17.226540497029429 Ha |
 | `04-embedding-methods/h2o-qmmm-gaussian.inp` | Gaussian electrostatic QMMM | 036, 037, 038, 039 | energy -16.860414497766239 Ha |
 | `04-embedding-methods/ch3oh-resp-charges.inp` | RESP charge fitting | 040, 041, 042 | energy -23.909587912298466 Ha; RESP RMS 7.55141E-05 |
 | `04-embedding-methods/h2o-h2-dfet.inp` | density functional embedding | 043, 044, 045, 046, 047, 048, 049 | energy -18.321636385557674 Ha |
+
+### 5. Magnetic Resonance
+
+| input | topic | based on snippets | local test result |
+| --- | --- | --- | --- |
 | `05-magnetic-resonance/h2o-nmr-linear-response.inp` | NMR linear response | 050, 051, 052, 053 | shielding checksum 0.605916E+02 |
 | `05-magnetic-resonance/no2-epr-g-tensor.inp` | EPR g-tensor linear response | 050, 054 | EPR checksum -0.130768E-02 |
 | `05-magnetic-resonance/h2o-hyperfine-coupling.inp` | EPR hyperfine coupling tensor | 055 | O Sca-Rel A_iso -118.2292921806 MHz; energy -75.901123242692378 Ha |
+
+### 6. Optical Spectroscopy
+
+| input | topic | based on snippets | local test result |
+| --- | --- | --- | --- |
 | `06-optical-spectroscopy/h2o-tddfpt.inp` | linear-response TDDFPT | 056 | first excitation 8.43471 eV |
 | `06-optical-spectroscopy/h2o-stda-tddfpt.inp` | sTDA-TDDFPT | 057, 058, 059 | first excitation 7.86094 eV |
+
+### 7. Excited-State Dynamics
+
+| input | topic | based on snippets | local test result |
+| --- | --- | --- | --- |
 | `07-excited-state-dynamics/h2o-real-time-propagation.inp` | real-time propagation | 061, 069 | final total energy -17.17816551662580 Ha |
+
+### 8. X-Ray Spectroscopy
+
+| input | topic | based on snippets | local test result |
+| --- | --- | --- | --- |
 | `08-x-ray-spectroscopy/co-xas-transition-potential.inp` | XAS transition potential | 064 | energy -92.844208496940453 Ha |
 | `08-x-ray-spectroscopy/h2o-xastdp-gw2x.inp` | XAS_TDP with GW2X correction | 065, 066, 067 | first XAS excitation 538.170258 eV; energy -75.956287566248847 Ha |
 | `08-x-ray-spectroscopy/h2o-real-time-gaussian-field.inp` | real-time propagation with Gaussian field | 070 | final RTP energy -17.17816621169307 Ha |
+
+### 9. Energy Decomposition Analysis
+
+| input | topic | based on snippets | local test result |
+| --- | --- | --- | --- |
 | `09-energy-decomposition-analysis/h2o-almo-eda.inp` | ALMO energy decomposition | 071, 073 | energy -85.963743073058524 Ha |
 | `09-energy-decomposition-analysis/lif-almo-ionic.inp` | ionic ALMO electron assignment | 072, 073 | energy -127.539319485670845 Ha |
+
+### 10. Finite-Temperature Effects
+
+| input | topic | based on snippets | local test result |
+| --- | --- | --- | --- |
 | `10-finite-temperature-effects/h2o-nnp-committee-md.inp` | committee NNP molecular dynamics | 074, 075, 076 | final energy 58.648809523054418 Ha |
 | `10-finite-temperature-effects/h2o-nnp-biased-md.inp` | biased committee NNP molecular dynamics | 074, 075, 076, 077 | final energy 58.661222155637667 Ha |
 | `10-finite-temperature-effects/h2o-pint-nve.inp` | path-integral molecular dynamics | 078 | final PINT energy -17.137402749384318 Ha |
@@ -62,9 +107,16 @@ To smoke-test the complete set:
 python3 run_smoke_tests.py --cp2k /path/to/cp2k.psmp --data-dir /path/to/cp2k/data --jobs 1
 ```
 
+To run only a representative quick subset with numeric output checks:
+
+```bash
+python3 run_smoke_tests.py --cp2k /path/to/cp2k.psmp --data-dir /path/to/cp2k/data --quick
+```
+
 Use `--jobs N` only when the machine has enough cores and memory for several independent CP2K
 runs. Each input is executed in its own work directory.
 
 The results above were checked with a local `cp2k.psmp` build using `OMP_NUM_THREADS=1`.
-Snippets for SIRIUS and the larger GW/BSE workflows remain in `../paper-snippets/` because they
-can require optional libraries, external data, or substantially larger production-style settings.
+Snippets for SIRIUS and the larger GW/BSE, real-time XAS, Voronoi, NEWTON-X, and bosonic helium
+workflows are tracked in `../optional-workflows/` because they can require optional libraries,
+external data, or substantially larger production-style settings.

--- a/cp2k-made-simple/runnable/README.md
+++ b/cp2k-made-simple/runnable/README.md
@@ -50,6 +50,15 @@ CP2K_DATA_DIR=/path/to/cp2k/data cp2k.psmp -i 02-total-energy-and-force-methods/
 
 When CP2K has been installed with a configured data directory, `CP2K_DATA_DIR` is not needed.
 
+To smoke-test the complete set:
+
+```bash
+python3 run_smoke_tests.py --cp2k /path/to/cp2k.psmp --data-dir /path/to/cp2k/data --jobs 1
+```
+
+Use `--jobs N` only when the machine has enough cores and memory for several independent CP2K
+runs. Each input is executed in its own work directory.
+
 The results above were checked with a local `cp2k.psmp` build using `OMP_NUM_THREADS=1`.
 Snippets for SIRIUS and the larger GW/BSE workflows remain in `../paper-snippets/` because they
 can require optional libraries, external data, or substantially larger production-style settings.

--- a/cp2k-made-simple/runnable/generate_readme.py
+++ b/cp2k-made-simple/runnable/generate_readme.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Generate the runnable-example tables in README.md from manifest.tsv."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parent
+MANIFEST = ROOT / "manifest.tsv"
+README = ROOT / "README.md"
+BEGIN_MARKER = "<!-- BEGIN GENERATED EXAMPLES -->"
+END_MARKER = "<!-- END GENERATED EXAMPLES -->"
+
+CHAPTER_TITLES = {
+    "02-total-energy-and-force-methods": "2. Total Energy and Force Methods",
+    "03-electronic-band-structure": "3. Electronic Band Structure",
+    "04-embedding-methods": "4. Embedding Methods",
+    "05-magnetic-resonance": "5. Magnetic Resonance",
+    "06-optical-spectroscopy": "6. Optical Spectroscopy",
+    "07-excited-state-dynamics": "7. Excited-State Dynamics",
+    "08-x-ray-spectroscopy": "8. X-Ray Spectroscopy",
+    "09-energy-decomposition-analysis": "9. Energy Decomposition Analysis",
+    "10-finite-temperature-effects": "10. Finite-Temperature Effects",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail if README.md is stale")
+    return parser.parse_args()
+
+
+def read_manifest() -> list[dict[str, str]]:
+    with MANIFEST.open(encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def markdown_cell(value: str) -> str:
+    return value.replace("|", r"\|")
+
+
+def format_snippets(value: str) -> str:
+    return ", ".join(part.strip() for part in value.split(",") if part.strip())
+
+
+def chapter_key(row: dict[str, str]) -> str:
+    return row["file"].split("/", 1)[0]
+
+
+def generate_examples(rows: list[dict[str, str]]) -> str:
+    lines = [BEGIN_MARKER]
+    current_chapter = None
+    for row in rows:
+        chapter = chapter_key(row)
+        if chapter != current_chapter:
+            if current_chapter is not None:
+                lines.append("")
+            current_chapter = chapter
+            lines.extend(
+                [
+                    f"### {CHAPTER_TITLES.get(chapter, chapter)}",
+                    "",
+                    "| input | topic | based on snippets | local test result | quick |",
+                    "| --- | --- | --- | --- | --- |",
+                ]
+            )
+
+        quick = "yes" if row.get("quick", "").strip().lower() == "yes" else "-"
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    f"`{markdown_cell(row['file'])}`",
+                    markdown_cell(row["topic"]),
+                    markdown_cell(format_snippets(row["snippets"])),
+                    markdown_cell(row["result"]),
+                    quick,
+                ]
+            )
+            + " |"
+        )
+    lines.extend(["", END_MARKER])
+    return "\n".join(lines)
+
+
+def replace_generated_block(readme: str, generated: str) -> str:
+    before, marker, rest = readme.partition(BEGIN_MARKER)
+    if not marker:
+        raise SystemExit(f"Missing marker in {README}: {BEGIN_MARKER}")
+    _, marker, after = rest.partition(END_MARKER)
+    if not marker:
+        raise SystemExit(f"Missing marker in {README}: {END_MARKER}")
+    return before.rstrip() + "\n\n" + generated + "\n\n" + after.lstrip()
+
+
+def main() -> int:
+    args = parse_args()
+    readme = README.read_text(encoding="utf-8")
+    generated = generate_examples(read_manifest())
+    updated = replace_generated_block(readme, generated)
+
+    if args.check:
+        if updated != readme:
+            print(
+                "README.md is stale; run cp2k-made-simple/runnable/generate_readme.py.",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    README.write_text(updated, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cp2k-made-simple/runnable/manifest.tsv
+++ b/cp2k-made-simple/runnable/manifest.tsv
@@ -1,34 +1,34 @@
-file	topic	snippets	test_status	result
-02-total-energy-and-force-methods/h2o-gpw-pbe.inp	GPW/PBE single point	001,002	passed	energy -17.212337144585153 Ha
-02-total-energy-and-force-methods/h2o-gpw-ot.inp	GPW/PBE with OT	001,005,006	passed	energy -17.212337144506982 Ha
-02-total-energy-and-force-methods/h2o-gpw-smearing.inp	GPW/PBE with diagonalization and smearing	001,005	passed	energy -17.212334309139813 Ha
-02-total-energy-and-force-methods/h2o-gapw-all-electron.inp	all-electron GAPW/PBE	003,004	passed	energy -76.238068224190314 Ha
-02-total-energy-and-force-methods/h2o-pbe0-admm.inp	hybrid DFT with ADMM	010,011,012,013	passed	energy -17.151344159601688 Ha
-02-total-energy-and-force-methods/h2o-dft-plus-u.inp	DFT+U setup	022,023,024,025	passed	energy -17.180669501745012 Ha
-02-total-energy-and-force-methods/h2o-ri-mp2.inp	RI-MP2 correlation	016,017	passed	energy -17.170315778164436 Ha
-03-electronic-band-structure/diamond-kpoints-band-structure.inp	k-point band output	007,008,030,031	passed	energy -45.498947901745879 Ha
-04-embedding-methods/h2o-sccs-solvation.inp	SCCS implicit solvation	032,033,034,035	passed	energy -17.226540497029429 Ha
-04-embedding-methods/h2o-qmmm-gaussian.inp	Gaussian electrostatic QMMM	036,037,038,039	passed	energy -16.860414497766239 Ha
-04-embedding-methods/ch3oh-resp-charges.inp	RESP charge fitting	040,041,042	passed	energy -23.909587912298466 Ha; RESP RMS 7.55141E-05
-04-embedding-methods/h2o-h2-dfet.inp	density functional embedding	043,044,045,046,047,048,049	passed	energy -18.321636385557674 Ha
-05-magnetic-resonance/h2o-nmr-linear-response.inp	NMR linear response	050,051,052,053	passed	shielding checksum 0.605916E+02
-05-magnetic-resonance/no2-epr-g-tensor.inp	EPR g-tensor linear response	050,054	passed	EPR checksum -0.130768E-02
-05-magnetic-resonance/h2o-hyperfine-coupling.inp	EPR hyperfine coupling tensor	055	passed	O Sca-Rel A_iso -118.2292921806 MHz; energy -75.901123242692378 Ha
-06-optical-spectroscopy/h2o-tddfpt.inp	linear-response TDDFPT	056	passed	first excitation 8.43471 eV
-06-optical-spectroscopy/h2o-stda-tddfpt.inp	sTDA-TDDFPT	057,058,059	passed	first excitation 7.86094 eV
-07-excited-state-dynamics/h2o-real-time-propagation.inp	real-time propagation	061,069	passed	final total energy -17.17816551662580 Ha
-08-x-ray-spectroscopy/co-xas-transition-potential.inp	XAS transition potential	064	passed	energy -92.844208496940453 Ha
-08-x-ray-spectroscopy/h2o-xastdp-gw2x.inp	XAS_TDP with GW2X correction	065,066,067	passed	first XAS excitation 538.170258 eV; energy -75.956287566248847 Ha
-08-x-ray-spectroscopy/h2o-real-time-gaussian-field.inp	real-time propagation with Gaussian field	070	passed	final RTP energy -17.17816621169307 Ha
-09-energy-decomposition-analysis/h2o-almo-eda.inp	ALMO energy decomposition	071,073	passed	energy -85.963743073058524 Ha
-09-energy-decomposition-analysis/lif-almo-ionic.inp	ionic ALMO electron assignment	072,073	passed	energy -127.539319485670845 Ha
-10-finite-temperature-effects/h2o-nnp-committee-md.inp	committee NNP molecular dynamics	074,075,076	passed	final energy 58.648809523054418 Ha
-10-finite-temperature-effects/h2o-nnp-biased-md.inp	biased committee NNP molecular dynamics	074,075,076,077	passed	final energy 58.661222155637667 Ha
-10-finite-temperature-effects/h2o-pint-nve.inp	path-integral molecular dynamics	078	passed	final PINT energy -17.137402749384318 Ha
-10-finite-temperature-effects/h2o-pint-nose.inp	PINT with Nose thermostat	078,079	passed	final PINT energy -17.129535930553633 Ha
-10-finite-temperature-effects/h2o-pint-pile.inp	PINT with PILE thermostat	078,080	passed	final PINT energy -68.549498536850606 Ha
-10-finite-temperature-effects/h2o-pint-qtb.inp	PINT with QTB thermostat	078,081	passed	final PINT energy -68.549621077706419 Ha
-10-finite-temperature-effects/h2o-vibrational-analysis.inp	vibrational analysis	086	passed	first frequencies 0.000000 cm^-1
-10-finite-temperature-effects/h2o-periodic-efield.inp	periodic electric field	087,090	passed	energy -16.553933618515682 Ha
-10-finite-temperature-effects/h2o-orbital-localization.inp	orbital localization and Wannier centers	088	passed	localization converged in 26 iterations; energy -17.186709451452117 Ha
-10-finite-temperature-effects/h2o-linear-response-polarizability.inp	linear-response polarizability	091	passed	polarizability xx/yy/zz 0.006179870499/0.958172935260/0.397344896793 ang^3
+file	topic	snippets	test_status	result	check_pattern	expected_value	tolerance	quick	requires_feature
+02-total-energy-and-force-methods/h2o-gpw-pbe.inp	GPW/PBE single point	001,002	passed	energy -17.212337144585153 Ha	ENERGY| Total FORCE_EVAL	-17.212337144585153	1e-10	yes	-
+02-total-energy-and-force-methods/h2o-gpw-ot.inp	GPW/PBE with OT	001,005,006	passed	energy -17.212337144506982 Ha	ENERGY| Total FORCE_EVAL	-17.212337144506982	1e-10	no	-
+02-total-energy-and-force-methods/h2o-gpw-smearing.inp	GPW/PBE with diagonalization and smearing	001,005	passed	energy -17.212334309139813 Ha	ENERGY| Total FORCE_EVAL	-17.212334309139813	1e-10	no	-
+02-total-energy-and-force-methods/h2o-gapw-all-electron.inp	all-electron GAPW/PBE	003,004	passed	energy -76.238068224190314 Ha	ENERGY| Total FORCE_EVAL	-76.238068224190314	1e-10	no	-
+02-total-energy-and-force-methods/h2o-pbe0-admm.inp	hybrid DFT with ADMM	010,011,012,013	passed	energy -17.151344159601688 Ha	ENERGY| Total FORCE_EVAL	-17.151344159601688	1e-10	no	-
+02-total-energy-and-force-methods/h2o-dft-plus-u.inp	DFT+U setup	022,023,024,025	passed	energy -17.180669501745012 Ha	ENERGY| Total FORCE_EVAL	-17.180669501745012	1e-10	yes	-
+02-total-energy-and-force-methods/h2o-ri-mp2.inp	RI-MP2 correlation	016,017	passed	energy -17.170315778164436 Ha	ENERGY| Total FORCE_EVAL	-17.170315778164436	1e-10	no	-
+03-electronic-band-structure/diamond-kpoints-band-structure.inp	k-point band output	007,008,030,031	passed	energy -45.498947901745879 Ha	ENERGY| Total FORCE_EVAL	-45.498947901745879	1e-10	no	-
+04-embedding-methods/h2o-sccs-solvation.inp	SCCS implicit solvation	032,033,034,035	passed	energy -17.226540497029429 Ha	ENERGY| Total FORCE_EVAL	-17.226540497029429	1e-10	no	-
+04-embedding-methods/h2o-qmmm-gaussian.inp	Gaussian electrostatic QMMM	036,037,038,039	passed	energy -16.860414497766239 Ha	ENERGY| Total FORCE_EVAL	-16.860414497766239	1e-10	yes	-
+04-embedding-methods/ch3oh-resp-charges.inp	RESP charge fitting	040,041,042	passed	energy -23.909587912298466 Ha; RESP RMS 7.55141E-05	ENERGY| Total FORCE_EVAL	-23.909587912298466	1e-10	no	-
+04-embedding-methods/h2o-h2-dfet.inp	density functional embedding	043,044,045,046,047,048,049	passed	energy -18.321636385557674 Ha	ENERGY| Total FORCE_EVAL	-18.321636385557674	1e-10	no	-
+05-magnetic-resonance/h2o-nmr-linear-response.inp	NMR linear response	050,051,052,053	passed	shielding checksum 0.605916E+02	Localization  for spin	12	0	yes	-
+05-magnetic-resonance/no2-epr-g-tensor.inp	EPR g-tensor linear response	050,054	passed	EPR checksum -0.130768E-02	Localization  for spin   2	10	0	no	-
+05-magnetic-resonance/h2o-hyperfine-coupling.inp	EPR hyperfine coupling tensor	055	passed	O Sca-Rel A_iso -118.2292921806 MHz; energy -75.901123242692378 Ha	1 O   17	-118.2292921806	1e-7	no	-
+06-optical-spectroscopy/h2o-tddfpt.inp	linear-response TDDFPT	056	passed	first excitation 8.43471 eV	ENERGY| Total FORCE_EVAL	-17.212337144586243	1e-10	no	-
+06-optical-spectroscopy/h2o-stda-tddfpt.inp	sTDA-TDDFPT	057,058,059	passed	first excitation 7.86094 eV	ENERGY| Total FORCE_EVAL	-17.226633774428187	1e-10	yes	-
+07-excited-state-dynamics/h2o-real-time-propagation.inp	real-time propagation	061,069	passed	final total energy -17.17816551662580 Ha	Total energy:	-17.17816551662580	1e-10	no	-
+08-x-ray-spectroscopy/co-xas-transition-potential.inp	XAS transition potential	064	passed	energy -92.844208496940453 Ha	ENERGY| Total FORCE_EVAL	-92.844208496940453	1e-10	no	-
+08-x-ray-spectroscopy/h2o-xastdp-gw2x.inp	XAS_TDP with GW2X correction	065,066,067	passed	first XAS excitation 538.170258 eV; energy -75.956287566248847 Ha	ENERGY| Total FORCE_EVAL	-75.956287566248847	1e-10	no	-
+08-x-ray-spectroscopy/h2o-real-time-gaussian-field.inp	real-time propagation with Gaussian field	070	passed	final RTP energy -17.17816621169307 Ha	Total energy:	-17.17816621169307	1e-10	yes	-
+09-energy-decomposition-analysis/h2o-almo-eda.inp	ALMO energy decomposition	071,073	passed	energy -85.963743073058524 Ha	ENERGY| Total FORCE_EVAL	-85.963743073058524	1e-10	no	-
+09-energy-decomposition-analysis/lif-almo-ionic.inp	ionic ALMO electron assignment	072,073	passed	energy -127.539319485670845 Ha	ENERGY| Total FORCE_EVAL	-127.539319485670845	1e-10	no	-
+10-finite-temperature-effects/h2o-nnp-committee-md.inp	committee NNP molecular dynamics	074,075,076	passed	final energy 58.648809523054418 Ha	ENERGY| Total FORCE_EVAL	58.648809523054418	1e-10	yes	NNP data
+10-finite-temperature-effects/h2o-nnp-biased-md.inp	biased committee NNP molecular dynamics	074,075,076,077	passed	final energy 58.661222155637667 Ha	ENERGY| Total FORCE_EVAL	58.661222155637667	1e-10	no	NNP data
+10-finite-temperature-effects/h2o-pint-nve.inp	path-integral molecular dynamics	078	passed	final PINT energy -17.137402749384318 Ha	PINT| Total energy	-17.137402749384318	1e-10	no	-
+10-finite-temperature-effects/h2o-pint-nose.inp	PINT with Nose thermostat	078,079	passed	final PINT energy -17.129535930553633 Ha	PINT| Total energy	-17.129535930553633	1e-10	no	-
+10-finite-temperature-effects/h2o-pint-pile.inp	PINT with PILE thermostat	078,080	passed	final PINT energy -68.549498536850606 Ha	PINT| Total energy	-68.549498536850606	1e-10	no	-
+10-finite-temperature-effects/h2o-pint-qtb.inp	PINT with QTB thermostat	078,081	passed	final PINT energy -68.549621077706419 Ha	PINT| Total energy	-68.549621077706419	1e-10	no	-
+10-finite-temperature-effects/h2o-vibrational-analysis.inp	vibrational analysis	086	passed	first frequencies 0.000000 cm^-1	VIB|                                     Total energy	0.0	1e-12	no	-
+10-finite-temperature-effects/h2o-periodic-efield.inp	periodic electric field	087,090	passed	energy -16.553933618515682 Ha	ENERGY| Total FORCE_EVAL	-16.553933618515682	1e-10	no	-
+10-finite-temperature-effects/h2o-orbital-localization.inp	orbital localization and Wannier centers	088	passed	localization converged in 26 iterations; energy -17.186709451452117 Ha	Localization  for spin	26	0	yes	-
+10-finite-temperature-effects/h2o-linear-response-polarizability.inp	linear-response polarizability	091	passed	polarizability xx/yy/zz 0.006179870499/0.958172935260/0.397344896793 ang^3	POLAR| xx,yy,zz	0.397344896793	1e-10	yes	-

--- a/cp2k-made-simple/runnable/manifest.tsv
+++ b/cp2k-made-simple/runnable/manifest.tsv
@@ -13,11 +13,13 @@ file	topic	snippets	test_status	result
 04-embedding-methods/h2o-h2-dfet.inp	density functional embedding	043,044,045,046,047,048,049	passed	energy -18.321636385557674 Ha
 05-magnetic-resonance/h2o-nmr-linear-response.inp	NMR linear response	050,051,052,053	passed	shielding checksum 0.605916E+02
 05-magnetic-resonance/no2-epr-g-tensor.inp	EPR g-tensor linear response	050,054	passed	EPR checksum -0.130768E-02
+05-magnetic-resonance/h2o-hyperfine-coupling.inp	EPR hyperfine coupling tensor	055	passed	O Sca-Rel A_iso -118.2292921806 MHz; energy -75.901123242692378 Ha
 06-optical-spectroscopy/h2o-tddfpt.inp	linear-response TDDFPT	056	passed	first excitation 8.43471 eV
 06-optical-spectroscopy/h2o-stda-tddfpt.inp	sTDA-TDDFPT	057,058,059	passed	first excitation 7.86094 eV
 07-excited-state-dynamics/h2o-real-time-propagation.inp	real-time propagation	061,069	passed	final total energy -17.17816551662580 Ha
 08-x-ray-spectroscopy/co-xas-transition-potential.inp	XAS transition potential	064	passed	energy -92.844208496940453 Ha
 08-x-ray-spectroscopy/h2o-xastdp-gw2x.inp	XAS_TDP with GW2X correction	065,066,067	passed	first XAS excitation 538.170258 eV; energy -75.956287566248847 Ha
+08-x-ray-spectroscopy/h2o-real-time-gaussian-field.inp	real-time propagation with Gaussian field	070	passed	final RTP energy -17.17816621169307 Ha
 09-energy-decomposition-analysis/h2o-almo-eda.inp	ALMO energy decomposition	071,073	passed	energy -85.963743073058524 Ha
 09-energy-decomposition-analysis/lif-almo-ionic.inp	ionic ALMO electron assignment	072,073	passed	energy -127.539319485670845 Ha
 10-finite-temperature-effects/h2o-nnp-committee-md.inp	committee NNP molecular dynamics	074,075,076	passed	final energy 58.648809523054418 Ha
@@ -28,4 +30,5 @@ file	topic	snippets	test_status	result
 10-finite-temperature-effects/h2o-pint-qtb.inp	PINT with QTB thermostat	078,081	passed	final PINT energy -68.549621077706419 Ha
 10-finite-temperature-effects/h2o-vibrational-analysis.inp	vibrational analysis	086	passed	first frequencies 0.000000 cm^-1
 10-finite-temperature-effects/h2o-periodic-efield.inp	periodic electric field	087,090	passed	energy -16.553933618515682 Ha
+10-finite-temperature-effects/h2o-orbital-localization.inp	orbital localization and Wannier centers	088	passed	localization converged in 26 iterations; energy -17.186709451452117 Ha
 10-finite-temperature-effects/h2o-linear-response-polarizability.inp	linear-response polarizability	091	passed	polarizability xx/yy/zz 0.006179870499/0.958172935260/0.397344896793 ang^3

--- a/cp2k-made-simple/runnable/run_smoke_tests.py
+++ b/cp2k-made-simple/runnable/run_smoke_tests.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Run smoke tests for the CP2K Made Simple runnable inputs."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import csv
+import fnmatch
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+
+
+ROOT = Path(__file__).resolve().parent
+MANIFEST = ROOT / "manifest.tsv"
+
+
+@dataclass(frozen=True)
+class Example:
+    index: int
+    path: str
+
+
+@dataclass(frozen=True)
+class Result:
+    example: Example
+    elapsed: float
+    ok: bool
+    returncode: int | None
+    output: Path
+    message: str
+
+
+def find_cp2k(value: str | None) -> str:
+    if value:
+        cp2k = Path(value).expanduser()
+        if cp2k.exists():
+            return str(cp2k)
+        found = shutil.which(value)
+        if found:
+            return found
+        raise SystemExit(f"Could not find CP2K executable: {value}")
+
+    for name in ("cp2k.psmp", "cp2k.ssmp", "cp2k"):
+        found = shutil.which(name)
+        if found:
+            return found
+    raise SystemExit("Set --cp2k or CP2K_BINARY to a CP2K executable.")
+
+
+def read_manifest() -> list[Example]:
+    with MANIFEST.open(newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        return [Example(index=i, path=row["file"]) for i, row in enumerate(reader)]
+
+
+def select_examples(examples: list[Example], patterns: list[str]) -> list[Example]:
+    if not patterns:
+        return examples
+    selected = [
+        example
+        for example in examples
+        if any(fnmatch.fnmatch(example.path, pattern) for pattern in patterns)
+    ]
+    if not selected:
+        raise SystemExit(f"No examples matched: {', '.join(patterns)}")
+    return selected
+
+
+def summarize_output(output: Path) -> str:
+    markers = (
+        "ENERGY| Total FORCE_EVAL",
+        "PINT| Total energy",
+        "First singlet XAS excitation energy",
+        "POLAR| xx,yy,zz",
+        "Excitation energy",
+    )
+    summary = ""
+    with output.open(errors="replace") as handle:
+        for line in handle:
+            if any(marker in line for marker in markers):
+                summary = line.strip()
+    return summary
+
+
+def run_example(
+    example: Example,
+    cp2k: str,
+    data_dir: str | None,
+    work_root: Path,
+    omp_threads: int,
+    timeout: float | None,
+) -> Result:
+    stem = Path(example.path).with_suffix("").as_posix().replace("/", "__")
+    work_dir = work_root / stem
+    work_dir.mkdir(parents=True, exist_ok=True)
+    output = work_dir / "out.txt"
+    env = os.environ.copy()
+    env["OMP_NUM_THREADS"] = str(omp_threads)
+    if data_dir:
+        env["CP2K_DATA_DIR"] = data_dir
+
+    start = time.monotonic()
+    try:
+        completed = subprocess.run(
+            [cp2k, "-i", str(ROOT / example.path), "-o", "out.txt"],
+            cwd=work_dir,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        elapsed = time.monotonic() - start
+        return Result(example, elapsed, False, None, output, "timed out")
+
+    elapsed = time.monotonic() - start
+    if completed.returncode != 0:
+        return Result(example, elapsed, False, completed.returncode, output, "nonzero exit")
+    if not output.exists():
+        return Result(example, elapsed, False, completed.returncode, output, "missing output")
+
+    summary = summarize_output(output)
+    if "PROGRAM ENDED" not in output.read_text(errors="replace"):
+        return Result(example, elapsed, False, completed.returncode, output, "missing PROGRAM ENDED")
+    return Result(example, elapsed, True, completed.returncode, output, summary)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cp2k", default=os.environ.get("CP2K_BINARY"))
+    parser.add_argument("--data-dir", default=os.environ.get("CP2K_DATA_DIR"))
+    parser.add_argument("--jobs", type=int, default=1)
+    parser.add_argument("--omp-threads", type=int, default=1)
+    parser.add_argument("--timeout", type=float, default=0.0, help="seconds per input, 0 disables")
+    parser.add_argument("--work-dir", type=Path, default=None)
+    parser.add_argument("--keep", action="store_true", help="keep the temporary work directory")
+    parser.add_argument("--list", action="store_true", help="list selected examples without running")
+    parser.add_argument("--only", action="append", default=[], help="glob for input paths")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.jobs < 1:
+        raise SystemExit("--jobs must be at least 1")
+    if args.omp_threads < 1:
+        raise SystemExit("--omp-threads must be at least 1")
+
+    examples = select_examples(read_manifest(), args.only)
+    if args.list:
+        for example in examples:
+            print(example.path)
+        return 0
+
+    cp2k = find_cp2k(args.cp2k)
+    timeout = args.timeout if args.timeout > 0 else None
+    created_temp = args.work_dir is None
+    work_root = args.work_dir or Path(tempfile.mkdtemp(prefix="cp2k-made-simple-smoke."))
+    work_root.mkdir(parents=True, exist_ok=True)
+
+    print(f"CP2K: {cp2k}", flush=True)
+    if args.data_dir:
+        print(f"CP2K_DATA_DIR: {args.data_dir}", flush=True)
+    print(f"Work directory: {work_root}", flush=True)
+    print(f"Examples: {len(examples)}", flush=True)
+    print(f"Jobs: {args.jobs}; OMP threads per job: {args.omp_threads}", flush=True)
+
+    results: list[Result] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as executor:
+        futures = [
+            executor.submit(
+                run_example,
+                example,
+                cp2k,
+                args.data_dir,
+                work_root,
+                args.omp_threads,
+                timeout,
+            )
+            for example in examples
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            result = future.result()
+            results.append(result)
+            status = "PASS" if result.ok else "FAIL"
+            print(f"{status} {result.elapsed:7.2f}s {result.example.path}", flush=True)
+            if result.message:
+                print(f"     {result.message}", flush=True)
+
+    results.sort(key=lambda result: result.example.index)
+    failed = [result for result in results if not result.ok]
+    if failed:
+        print("\nFailures:", flush=True)
+        for result in failed:
+            print(f"- {result.example.path}: {result.message} ({result.output})", flush=True)
+        return 1
+
+    if created_temp and not args.keep:
+        shutil.rmtree(work_root)
+    print("\nAll smoke tests passed.", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cp2k-made-simple/runnable/run_smoke_tests.py
+++ b/cp2k-made-simple/runnable/run_smoke_tests.py
@@ -76,10 +76,13 @@ def select_examples(examples: list[Example], patterns: list[str]) -> list[Exampl
 def summarize_output(output: Path) -> str:
     markers = (
         "ENERGY| Total FORCE_EVAL",
+        "Total energy:",
         "PINT| Total energy",
         "First singlet XAS excitation energy",
         "POLAR| xx,yy,zz",
         "Excitation energy",
+        "Sca-Rel A_iso",
+        "Localization  for spin",
     )
     summary = ""
     with output.open(errors="replace") as handle:

--- a/cp2k-made-simple/runnable/run_smoke_tests.py
+++ b/cp2k-made-simple/runnable/run_smoke_tests.py
@@ -9,6 +9,7 @@ import csv
 import fnmatch
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import sys
@@ -25,6 +26,11 @@ MANIFEST = ROOT / "manifest.tsv"
 class Example:
     index: int
     path: str
+    check_pattern: str = ""
+    expected_value: float | None = None
+    tolerance: float | None = None
+    quick: bool = False
+    requires_feature: str = ""
 
 
 @dataclass(frozen=True)
@@ -35,6 +41,9 @@ class Result:
     returncode: int | None
     output: Path
     message: str
+
+
+FLOAT_RE = re.compile(r"[-+]?(?:\d+\.\d*|\.\d+|\d+)(?:[Ee][-+]?\d+)?")
 
 
 def find_cp2k(value: str | None) -> str:
@@ -57,10 +66,28 @@ def find_cp2k(value: str | None) -> str:
 def read_manifest() -> list[Example]:
     with MANIFEST.open(newline="") as handle:
         reader = csv.DictReader(handle, delimiter="\t")
-        return [Example(index=i, path=row["file"]) for i, row in enumerate(reader)]
+        examples = []
+        for i, row in enumerate(reader):
+            expected = row.get("expected_value", "").strip()
+            tolerance = row.get("tolerance", "").strip()
+            requires_feature = row.get("requires_feature", "").strip()
+            examples.append(
+                Example(
+                    index=i,
+                    path=row["file"],
+                    check_pattern=row.get("check_pattern", "").strip(),
+                    expected_value=float(expected) if expected else None,
+                    tolerance=float(tolerance) if tolerance else None,
+                    quick=row.get("quick", "").strip().lower() in {"1", "true", "yes", "y"},
+                    requires_feature="" if requires_feature == "-" else requires_feature,
+                )
+            )
+        return examples
 
 
-def select_examples(examples: list[Example], patterns: list[str]) -> list[Example]:
+def select_examples(examples: list[Example], patterns: list[str], quick: bool) -> list[Example]:
+    if quick:
+        examples = [example for example in examples if example.quick]
     if not patterns:
         return examples
     selected = [
@@ -71,6 +98,51 @@ def select_examples(examples: list[Example], patterns: list[str]) -> list[Exampl
     if not selected:
         raise SystemExit(f"No examples matched: {', '.join(patterns)}")
     return selected
+
+
+def matching_line(output: Path, pattern: str) -> str:
+    match = ""
+    with output.open(errors="replace") as handle:
+        for line in handle:
+            if pattern in line:
+                match = line.strip()
+    return match
+
+
+def extract_last_number(line: str) -> float | None:
+    matches = FLOAT_RE.findall(line)
+    if not matches:
+        return None
+    return float(matches[-1])
+
+
+def validate_output(example: Example, output: Path) -> tuple[bool, str]:
+    if "PROGRAM ENDED" not in output.read_text(errors="replace"):
+        return False, "missing PROGRAM ENDED"
+
+    if not example.check_pattern:
+        return True, summarize_output(output)
+
+    line = matching_line(output, example.check_pattern)
+    if not line:
+        return False, f"missing marker: {example.check_pattern}"
+
+    if example.expected_value is None:
+        return True, line
+
+    actual = extract_last_number(line)
+    if actual is None:
+        return False, f"marker has no numeric value: {line}"
+
+    tolerance = example.tolerance if example.tolerance is not None else 0.0
+    delta = abs(actual - example.expected_value)
+    if delta > tolerance:
+        return (
+            False,
+            f"value {actual:.16g} differs from expected {example.expected_value:.16g} "
+            f"by {delta:.3g} > {tolerance:.3g}: {line}",
+        )
+    return True, line
 
 
 def summarize_output(output: Path) -> str:
@@ -131,10 +203,8 @@ def run_example(
     if not output.exists():
         return Result(example, elapsed, False, completed.returncode, output, "missing output")
 
-    summary = summarize_output(output)
-    if "PROGRAM ENDED" not in output.read_text(errors="replace"):
-        return Result(example, elapsed, False, completed.returncode, output, "missing PROGRAM ENDED")
-    return Result(example, elapsed, True, completed.returncode, output, summary)
+    ok, message = validate_output(example, output)
+    return Result(example, elapsed, ok, completed.returncode, output, message)
 
 
 def parse_args() -> argparse.Namespace:
@@ -147,6 +217,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--work-dir", type=Path, default=None)
     parser.add_argument("--keep", action="store_true", help="keep the temporary work directory")
     parser.add_argument("--list", action="store_true", help="list selected examples without running")
+    parser.add_argument("--quick", action="store_true", help="run only the quick manifest subset")
     parser.add_argument("--only", action="append", default=[], help="glob for input paths")
     return parser.parse_args()
 
@@ -158,7 +229,7 @@ def main() -> int:
     if args.omp_threads < 1:
         raise SystemExit("--omp-threads must be at least 1")
 
-    examples = select_examples(read_manifest(), args.only)
+    examples = select_examples(read_manifest(), args.only, args.quick)
     if args.list:
         for example in examples:
             print(example.path)
@@ -176,6 +247,8 @@ def main() -> int:
     print(f"Work directory: {work_root}", flush=True)
     print(f"Examples: {len(examples)}", flush=True)
     print(f"Jobs: {args.jobs}; OMP threads per job: {args.omp_threads}", flush=True)
+    if args.quick:
+        print("Mode: quick", flush=True)
 
     results: list[Result] = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as executor:

--- a/cp2k-made-simple/runnable/validate_manifest.py
+++ b/cp2k-made-simple/runnable/validate_manifest.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Validate the CP2K Made Simple runnable-example manifest."""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parent
+MANIFEST = ROOT / "manifest.tsv"
+
+EXPECTED_COLUMNS = [
+    "file",
+    "topic",
+    "snippets",
+    "test_status",
+    "result",
+    "check_pattern",
+    "expected_value",
+    "tolerance",
+    "quick",
+    "requires_feature",
+]
+VALID_QUICK = {"yes", "no"}
+VALID_STATUS = {"passed", "not_run", "skipped"}
+SNIPPET_RE = re.compile(r"\d{3}")
+
+
+def fail(errors: list[str], line: int | None, message: str) -> None:
+    prefix = f"line {line}: " if line is not None else ""
+    errors.append(prefix + message)
+
+
+def parse_float(errors: list[str], line: int, field: str, value: str) -> None:
+    try:
+        parsed = float(value)
+    except ValueError:
+        fail(errors, line, f"{field} is not a float: {value!r}")
+        return
+    if not math.isfinite(parsed):
+        fail(errors, line, f"{field} is not finite: {value!r}")
+    if field == "tolerance" and parsed < 0.0:
+        fail(errors, line, f"{field} must be non-negative: {value!r}")
+
+
+def manifest_rows(errors: list[str]) -> list[tuple[int, dict[str, str]]]:
+    with MANIFEST.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        if reader.fieldnames != EXPECTED_COLUMNS:
+            fail(
+                errors,
+                1,
+                f"unexpected columns: {reader.fieldnames!r}; expected {EXPECTED_COLUMNS!r}",
+            )
+            return []
+        return [(line, row) for line, row in enumerate(reader, start=2)]
+
+
+def runnable_inputs() -> set[str]:
+    return {
+        str(path.relative_to(ROOT))
+        for path in ROOT.glob("*/*.inp")
+        if path.is_file()
+    }
+
+
+def validate_row(errors: list[str], line: int, row: dict[str, str]) -> None:
+    path = row["file"]
+    if not path:
+        fail(errors, line, "file is empty")
+    elif path.startswith("/") or ".." in Path(path).parts:
+        fail(errors, line, f"file must be relative and stay below runnable/: {path!r}")
+    elif not path.endswith(".inp"):
+        fail(errors, line, f"file should point to a .inp file: {path!r}")
+    elif not (ROOT / path).is_file():
+        fail(errors, line, f"file does not exist: {path!r}")
+
+    for field in ("topic", "test_status", "result", "check_pattern"):
+        if not row[field]:
+            fail(errors, line, f"{field} is empty")
+
+    snippets = [part.strip() for part in row["snippets"].split(",") if part.strip()]
+    if not snippets:
+        fail(errors, line, "snippets is empty")
+    for snippet in snippets:
+        if not SNIPPET_RE.fullmatch(snippet):
+            fail(errors, line, f"invalid snippet id: {snippet!r}")
+
+    if row["test_status"] not in VALID_STATUS:
+        fail(errors, line, f"invalid test_status: {row['test_status']!r}")
+    if row["quick"] not in VALID_QUICK:
+        fail(errors, line, f"quick must be one of {sorted(VALID_QUICK)}: {row['quick']!r}")
+    if not row["requires_feature"]:
+        fail(errors, line, "requires_feature must be '-' or a feature note")
+
+    parse_float(errors, line, "expected_value", row["expected_value"])
+    parse_float(errors, line, "tolerance", row["tolerance"])
+
+
+def validate_manifest() -> list[str]:
+    errors: list[str] = []
+    rows = manifest_rows(errors)
+
+    seen: dict[str, int] = {}
+    for line, row in rows:
+        validate_row(errors, line, row)
+        path = row["file"]
+        if path in seen:
+            fail(errors, line, f"duplicate file entry, first seen on line {seen[path]}: {path!r}")
+        else:
+            seen[path] = line
+
+    manifest_files = set(seen)
+    actual_files = runnable_inputs()
+    for path in sorted(actual_files - manifest_files):
+        fail(errors, None, f"input missing from manifest: {path}")
+    for path in sorted(manifest_files - actual_files):
+        fail(errors, seen[path], f"manifest entry has no matching input: {path}")
+
+    return errors
+
+
+def main() -> int:
+    errors = validate_manifest()
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print(f"Validated {len(runnable_inputs())} runnable CP2K Made Simple inputs.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This PR expands the CP2K Made Simple example collection with additional runnable derived inputs,
guided workflows, optional workflow notes, and validation tooling.

Main changes:
- add additional runnable CP2K Made Simple inputs for hyperfine coupling, real-time Gaussian-field propagation, and orbital localization
- add guided workflow notes that group runnable examples into learning paths
- add optional workflow notes for SIRIUS, GW/BSE, real-time XAS, Voronoi, NEWTON-X, and bosonic helium PINT cases
- extend `runnable/manifest.tsv` with smoke-test markers, expected values, quick-test flags, and feature notes
- add `run_smoke_tests.py` with numeric output checks and `--quick` support
- generate the runnable README tables from the manifest via `generate_readme.py`
- add `validate_manifest.py` to catch missing inputs, stale manifest entries, malformed fields, and invalid quick/status values

## Testing

Run locally with a CP2K psmp build and `OMP_NUM_THREADS=1`:

- `python3 cp2k-made-simple/runnable/validate_manifest.py`
- `python3 cp2k-made-simple/runnable/generate_readme.py --check`
- `python3 -m py_compile cp2k-made-simple/runnable/*.py`
- `git diff --check`
- `python3 cp2k-made-simple/runnable/run_smoke_tests.py --cp2k /path/to/cp2k.psmp --data-dir /path/to/cp2k/data --jobs 1 --omp-threads 1 --quick`
- `python3 cp2k-made-simple/runnable/run_smoke_tests.py --cp2k /path/to/cp2k.psmp --data-dir /path/to/cp2k/data --jobs 1 --omp-threads 1`

Full smoke-test result: 33/33 runnable inputs passed.
Quick smoke-test result: 9/9 runnable inputs passed.